### PR TITLE
[#4] fix bug: camera in browser keeps on scanning

### DIFF
--- a/src/hooks/useMediaDevices.ts
+++ b/src/hooks/useMediaDevices.ts
@@ -10,6 +10,7 @@ const useMediaDevicesHook = (constraints?: MediaTrackConstraints) => {
 
     useEffect(() => {
         let mounted = true;
+        let mediaStream: MediaStream;
 
         let newConstraints: MediaStreamConstraints = {
             audio: false,
@@ -21,7 +22,7 @@ const useMediaDevicesHook = (constraints?: MediaTrackConstraints) => {
                 .getUserMedia(newConstraints)
                 .then((stream) => {
                     let settings: Array<MediaTrackSettings> = [];
-
+                    mediaStream = stream;
                     stream.getVideoTracks().forEach((track) => {
                         settings.push(track.getSettings());
                     });
@@ -37,6 +38,9 @@ const useMediaDevicesHook = (constraints?: MediaTrackConstraints) => {
         return () => {
             mounted = false;
             off(navigator.mediaDevices, 'devicechange', onChange);
+            mediaStream.getVideoTracks().forEach((track) => {
+                track.stop()
+            })
         };
     }, []);
 


### PR DESCRIPTION
fixes #4

turning off the camera on component unmount

here is a [video showing the bug fix](https://youtu.be/huwbnsFpDHM)
the camera light stays on until the code change, it stops on component unmount,
when you unmount the component, the light goes away

@yudielcurbelo @idindrakusuma 