### PR TITLE
useMediaDevices: fix race between cleanup and onChange

### DIFF
--- a/src/hooks/useMediaDevices.ts
+++ b/src/hooks/useMediaDevices.ts
@@ -38,9 +38,13 @@ const useMediaDevicesHook = (constraints?: MediaTrackConstraints) => {
         return () => {
             mounted = false;
             off(navigator.mediaDevices, 'devicechange', onChange);
-            mediaStream.getVideoTracks().forEach((track) => {
-                track.stop()
-            })
+            // the mediaStream is undefined if the cleanup is called before
+            // there's any stream available
+            if(typeof mediaStream !== 'undefined') {
+                mediaStream.getVideoTracks().forEach((track) => {
+                    track.stop()
+                });
+            }
         };
     }, []);
 


### PR DESCRIPTION
This PR fixes an issue where the useMediaDevices hook is cleaned up before a `mediaStream` is found. In that case the `mediaStream` is `undefined` but the code expects the `mediaStream.getVideoTracks()` method.