### PR TITLE
Fix styles option for video element and add className passthrough for container and video element

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ const App = () => {
 | `children`      | `ReactNode`                                   | No       | Optional children to render inside the scanner component.                |
 | `components`    | `IScannerComponents`                          | No       | Custom components to use within the scanner.                             |
 | `styles`        | `IScannerStyles`                              | No       | Custom styles to apply to the scanner and its elements.                  |
+| `classNames`    | `IScannerClassNames`                          | No       | Custom classNames to apply to the scanner and its elements.              |
 | `allowMultiple` | `boolean`                                     | No       | If `true`, ignore same barcode being scanned.                            |
 | `scanDelay`     | `number`                                      | No       | Delay in milliseconds between scans.                                     |
 

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -260,7 +260,7 @@ export function Scanner(props: IScannerProps) {
 
     return (
         <div style={{ ...defaultStyles.container, ...styles?.container }}>
-            <video ref={videoRef} style={{ ...defaultStyles.video, visibility: paused ? 'hidden' : 'visible' }} autoPlay muted playsInline />
+            <video ref={videoRef} style={{ ...defaultStyles.video, ...styles?.video, visibility: paused ? 'hidden' : 'visible' }} autoPlay muted playsInline />
             <canvas
                 ref={pauseFrameRef}
                 style={{

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -8,7 +8,7 @@ import useScanner from '../hooks/useScanner';
 
 import deepEqual from '../utilities/deepEqual';
 import { defaultComponents, defaultConstraints, defaultStyles } from '../misc';
-import { IDetectedBarcode, IPoint, IScannerComponents, IScannerStyles, TrackFunction } from '../types';
+import { IDetectedBarcode, IPoint, IScannerClassNames, IScannerComponents, IScannerStyles, TrackFunction } from '../types';
 
 export interface IScannerProps {
     onScan: (detectedCodes: IDetectedBarcode[]) => void;
@@ -18,6 +18,7 @@ export interface IScannerProps {
     children?: ReactNode;
     components?: IScannerComponents;
     styles?: IScannerStyles;
+    classNames?: IScannerClassNames;
     allowMultiple?: boolean;
     scanDelay?: number;
 }
@@ -116,7 +117,7 @@ function onFound(detectedCodes: IDetectedBarcode[], videoEl?: HTMLVideoElement |
 }
 
 export function Scanner(props: IScannerProps) {
-    const { onScan, constraints, formats = ['qr_code'], paused = false, components, children, styles, allowMultiple, scanDelay } = props;
+    const { onScan, constraints, formats = ['qr_code'], paused = false, components, children, styles, classNames, allowMultiple, scanDelay } = props;
 
     const videoRef = useRef<HTMLVideoElement>(null);
     const pauseFrameRef = useRef<HTMLCanvasElement>(null);
@@ -259,8 +260,8 @@ export function Scanner(props: IScannerProps) {
     }, [shouldScan]);
 
     return (
-        <div style={{ ...defaultStyles.container, ...styles?.container }}>
-            <video ref={videoRef} style={{ ...defaultStyles.video, ...styles?.video, visibility: paused ? 'hidden' : 'visible' }} autoPlay muted playsInline />
+        <div style={{ ...defaultStyles.container, ...styles?.container }} className={classNames?.container}>
+            <video ref={videoRef} style={{ ...defaultStyles.video, ...styles?.video, visibility: paused ? 'hidden' : 'visible' }} className={classNames?.video} autoPlay muted playsInline />
             <canvas
                 ref={pauseFrameRef}
                 style={{

--- a/src/types/IScannerClassNames.ts
+++ b/src/types/IScannerClassNames.ts
@@ -1,0 +1,4 @@
+export interface IScannerClassNames {
+    container?: string;
+    video?: string;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,4 +7,5 @@ export type { IStartTaskResult } from './IStartTaskResult';
 export type { IStopTaskResult } from './IStopTaskResult';
 export type { IStartCamera } from './IStartCamera';
 export type { IScannerStyles } from './IScannerStyles';
+export type { IScannerClassNames } from './IScannerClassNames';
 export type { TrackFunction } from './TrackFunction';


### PR DESCRIPTION
Currently the custom styles for video are completely ignored.
I also added the ability to pass in `classNames` for the container and video element.