### PR TITLE
refactor: Simplify useEffect Cleanup and Improve Timeout Handling

### DIFF
--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -163,9 +163,7 @@ export default function useCamera() {
     }, []);
 
     useEffect(() => {
-        return () => {
-            (async () => await stopCamera())();
-        };
+        return () => stopCamera();
     }, [stopCamera]);
 
     return {

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -41,13 +41,7 @@ export default function useCamera() {
             videoEl.src = stream.id;
         }
 
-        await Promise.race([
-            videoEl.play(),
-
-            new Promise((resolve) => setTimeout(resolve, 3000)).then(() => {
-                throw new Error('Loading camera stream timed out after 3 seconds.');
-            })
-        ]);
+        await Promise.race([videoEl.play(), new Promise((_, reject) => setTimeout(() => reject(new Error('Loading camera stream timed out after 3 seconds.')), 3000))]);
 
         await new Promise((resolve) => setTimeout(resolve, 500));
 


### PR DESCRIPTION
This pull request includes two key improvements to the camera handling logic:

1. Simplified the `useEffect` cleanup logic in `useCamera` hook.
   - The cleanup function now directly calls `stopCamera` without awaiting it, as awaiting is unnecessary in this context.
   - Commit: refactor: simplify cleanup logic in useEffect

2. Improved the timeout handling for video stream loading.
   - Replaced the previous method of handling the timeout using `resolve` and `then` with a more intuitive `reject` approach.
   - This change makes the code more readable and ensures that timeout errors are handled more clearly.
   - Commit: refactor: improve timeout handling for video stream loading

These changes enhance code readability and maintainability, ensuring a more robust camera initialization process.
