### PR TITLE
Upgraded barcode-detector to version 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "react-dom": "^17 || ^18 || ^19"
   },
   "dependencies": {
-    "barcode-detector": "3.0.3",
+    "barcode-detector": "3.0.5",
     "webrtc-adapter": "9.0.3"
   },
   "packageManager": "yarn@4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1875,7 +1875,7 @@ __metadata:
     "@types/node": "npm:^22.15.13"
     "@types/react": "npm:^19.1.3"
     "@types/react-dom": "npm:^19.1.3"
-    barcode-detector: "npm:3.0.3"
+    barcode-detector: "npm:3.0.5"
     rollup: "npm:^4.40.2"
     rollup-plugin-dts: "npm:^6.2.1"
     storybook: "npm:8.6.12"
@@ -2093,12 +2093,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"barcode-detector@npm:3.0.3":
-  version: 3.0.3
-  resolution: "barcode-detector@npm:3.0.3"
+"barcode-detector@npm:3.0.5":
+  version: 3.0.5
+  resolution: "barcode-detector@npm:3.0.5"
   dependencies:
-    zxing-wasm: "npm:^2.1.2"
-  checksum: 4de5171db98913b0bccb05d52aa2fa853096c3061da86e355a6105db830ba9ae746be32ae6a5ab65411604b401e517beffa1632b92fb226c1652b6f30cc24192
+    zxing-wasm: "npm:2.2.0"
+  checksum: 12a35c115d7e578a290a66b6a4b924b20b0f0477d67973899163d59af78d5f0ac7e8fc0f2e5dff311478f6b0cb3daefbad4ebd7dde54bdead24d8432dc4084d1
   languageName: node
   linkType: hard
 
@@ -5729,14 +5729,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zxing-wasm@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "zxing-wasm@npm:2.1.2"
+"zxing-wasm@npm:2.2.0":
+  version: 2.2.0
+  resolution: "zxing-wasm@npm:2.2.0"
   dependencies:
     "@types/emscripten": "npm:^1.40.1"
     type-fest: "npm:^4.41.0"
   peerDependencies:
     "@types/emscripten": ">=1.39.6"
-  checksum: 3b0476b4779fdb22de599022f6a8c51c77834422863d7412af35b3a7c682a48ac414ee6a3aafa264707b9beeb95fc20d933331f1d33b19d70c762509d5d1d5e6
+  checksum: 95cd6ec75247116ce6a57b1c261b5bd900e1888e4e6945d73d03ae0ae1b31b12b5955b995da85e03c0fa366f45b8859cf1dd4d2d142d0d7985abd68e48a4f430
   languageName: node
   linkType: hard


### PR DESCRIPTION
This resolves compatibility issues with offline barcode scanning. The previous version (3.0.0) used a caret range (^2.1.2) for the zxing-wasm dependency, which allowed npm to install zxing-wasm version 2.2.1. This newer version is incompatible with barcode-detector 3.0.3 when using prepareZXingModule for offline scanning functionality. In later versions they have now removed the caret.