### PR TITLE
feat: v3 scanner improvements (API, controls, a11y)

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Run Tests
-        run: npm test
+        run: npm run test:coverage
 
   build:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Barcode Detection API with React hooks and components.
   - [Scanner Props](#scanner-props)
   - [Scanner Ref](#scanner-ref)
   - [useDevices Hook](#usedevices-hook)
+  - [Headless Hooks](#headless-hooks-advanced)
   - [Utilities](#utilities)
 - [Supported Formats](#supported-formats)
 - [Type Definitions](#type-definitions)
@@ -241,17 +242,30 @@ function UIComponentsExample() {
     <Scanner
       onScan={(result) => console.log(result)}
       components={{
-        audio: true, // Play beep sound on scan
         onOff: true, // Show camera on/off button
         torch: true, // Show torch/flashlight button (if supported)
         zoom: true, // Show zoom control (if supported)
-        finder: true, // Show finder overlay
+        finder: true, // Show finder overlay (or pass a config object to theme it)
+        statusOverlay: true, // Show built-in loading/error UI
       }}
-      // Custom sound (base64 encoded audio)
+      // `sound` is a top-level prop, not part of `components`. It defaults to a
+      // beep; pass a URL/data URI for a custom sound, or `false` to disable it.
       sound="data:audio/mp3;base64,YOUR_BASE64_AUDIO_HERE"
     />
   );
 }
+```
+
+The built-in finder can be themed by passing an `IFinderConfig` object instead
+of `true`:
+
+```jsx
+<Scanner
+  onScan={(result) => console.log(result)}
+  components={{
+    finder: { color: '#22c55e', size: '60%', borderRadius: '1rem' },
+  }}
+/>
 ```
 
 ## API Reference
@@ -262,6 +276,9 @@ function UIComponentsExample() {
 |------------------|-----------------------------------------------|----------|--------------|--------------------------------------------------------------------------------------------------------------------|
 | `onScan`         | `(detectedCodes: IDetectedBarcode[]) => void` | Yes      | -            | Called when one or more barcodes are detected.                                                                     |
 | `onError`        | `(error: IScannerError) => void`              | No       | -            | Called with a typed error if the camera fails to start or detection fails. See [Type Definitions](#iscannererror). |
+| `onDetected`     | `(detectedCodes: IDetectedBarcode[]) => void` | No       | -            | Raw per-frame stream: fires on every frame containing a code, before the duplicate/`scanDelay` gating of `onScan`. |
+| `onCameraActive` | `(active: boolean) => void`                   | No       | -            | Fires when the camera becomes active (`true`) or stops (`false`).                                                  |
+| `onCapabilitiesChange` | `(capabilities, settings) => void`      | No       | -            | Fires when the active track's `MediaTrackCapabilities` / `MediaTrackSettings` change (e.g., torch/zoom support).   |
 | `constraints`    | `MediaTrackConstraints`                       | No       | `{}`         | Media track constraints applied to the video stream (e.g., `facingMode`, `deviceId`).                              |
 | `formats`        | `BarcodeFormat[]`                             | No       | All          | Barcode formats to detect. If omitted, all supported formats are detected.                                         |
 | `paused`         | `boolean`                                     | No       | `false`      | If `true`, the scanner pauses and displays the last frame.                                                         |
@@ -279,8 +296,8 @@ function UIComponentsExample() {
 
 ### Scanner Ref
 
-`Scanner` is a `forwardRef` component. Pass a ref to access the underlying
-video element and the active `MediaStream`:
+`Scanner` is a `forwardRef` component. Pass a ref to access the underlying video
+element/stream and to control the camera imperatively:
 
 ```tsx
 import { Scanner, type IScannerHandle } from '@yudiel/react-qr-scanner';
@@ -289,10 +306,11 @@ import { useRef } from 'react';
 function App() {
   const scannerRef = useRef<IScannerHandle>(null);
 
-  function snapshot() {
-    const video = scannerRef.current?.getVideoElement();
-    if (!video) return;
-    // ...take a still frame from the video element
+  async function saveSnapshot() {
+    const blob = await scannerRef.current?.snapshot();
+    if (blob) {
+      // ...upload, preview, or download the captured frame
+    }
   }
 
   return <Scanner ref={scannerRef} onScan={console.log} />;
@@ -303,10 +321,30 @@ The ref shape is:
 
 ```ts
 interface IScannerHandle {
+  /** The underlying <video> element, or null before mount / after unmount. */
   getVideoElement: () => HTMLVideoElement | null;
+  /** The active MediaStream, or null when the camera is stopped. */
   getStream: () => MediaStream | null;
+  /** Reads camera activity, capabilities, and track settings at call time. */
+  getCameraState: () => {
+    isActive: boolean;
+    capabilities: ICameraCapabilities; // MediaTrackCapabilities + typed torch/zoom
+    settings: ICameraSettings; // MediaTrackSettings + typed torch/zoom
+  };
+  /** Captures the current frame as a Blob (null if no frame is available). */
+  snapshot: (options?: { type?: string; quality?: number }) => Promise<Blob | null>;
+  /** Toggles the torch; pass a boolean to set it explicitly. */
+  toggleTorch: (on?: boolean) => Promise<void>;
+  /** Sets the zoom level (clamped by the device's supported range). */
+  setZoom: (value: number) => Promise<void>;
+  /** Stops and restarts the camera with the current constraints. */
+  restart: () => Promise<void>;
 }
 ```
+
+> To switch cameras, set `constraints={{ deviceId }}` (see
+> [Device Selection](#device-selection)) rather than an imperative call — the
+> scanner is constraint-driven, so a declarative `deviceId` is authoritative.
 
 ### useDevices Hook
 
@@ -336,6 +374,39 @@ function CameraList() {
   );
 }
 ```
+
+### Headless Hooks (advanced)
+
+If you need a fully custom UI, the low-level hooks that power `<Scanner>` are
+exported directly:
+
+- **`useCamera(options?)`** — manages the `MediaStream` lifecycle and returns
+  `{ capabilities, settings, startCamera, stopCamera, updateConstraints, getStream }`.
+- **`useScanner(props)`** — drives the barcode-detection loop against a video
+  element ref and returns `{ startScanning, stopScanning }`.
+- **`useDevices()`** — the device list shown above.
+
+```tsx
+import { useCamera, useScanner } from '@yudiel/react-qr-scanner';
+import { useRef } from 'react';
+
+function CustomScanner() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const camera = useCamera();
+
+  const { startScanning, stopScanning } = useScanner({
+    videoElementRef: videoRef,
+    onScan: (codes) => console.log(codes),
+    onFound: () => {}, // hook for drawing your own overlay
+  });
+
+  // ...wire startCamera/startScanning into your own effects and UI
+  return <video ref={videoRef} autoPlay muted playsInline />;
+}
+```
+
+These are lower-level than `<Scanner>` and the surface may evolve; prefer the
+`<Scanner>` component and its imperative ref unless you need full control.
 
 ### Utilities
 
@@ -493,7 +564,21 @@ interface IScannerComponents {
   onOff?: boolean;
   torch?: boolean;
   zoom?: boolean;
-  finder?: boolean;
+  // `true` for the default overlay, or a config object to theme it.
+  finder?: boolean | IFinderConfig;
+  // `true` for the default loading/error UI, or a render function.
+  statusOverlay?: boolean | ((state: IStatusOverlayState) => ReactNode);
+}
+
+interface IFinderConfig {
+  color?: string; // default '#ef4444'
+  size?: string; // CSS dimension, default '70%'
+  borderRadius?: string; // default '0.5rem'
+}
+
+interface IStatusOverlayState {
+  error: IScannerError | null;
+  isLoading: boolean;
 }
 ```
 
@@ -521,10 +606,21 @@ interface IScannerError {
 
 ### `IScannerHandle`
 
+See [Scanner Ref](#scanner-ref) for the full shape:
+
 ```typescript
 interface IScannerHandle {
   getVideoElement: () => HTMLVideoElement | null;
   getStream: () => MediaStream | null;
+  getCameraState: () => {
+    isActive: boolean;
+    capabilities: ICameraCapabilities; // MediaTrackCapabilities + typed torch/zoom
+    settings: ICameraSettings; // MediaTrackSettings + typed torch/zoom
+  };
+  snapshot: (options?: { type?: string; quality?: number }) => Promise<Blob | null>;
+  toggleTorch: (on?: boolean) => Promise<void>;
+  setZoom: (value: number) => Promise<void>;
+  restart: () => Promise<void>;
 }
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
 	},
 	"files": {
 		"ignoreUnknown": false,
-		"includes": ["src/**", "stories/**"]
+		"includes": ["src/**", "stories/**", "test/**"]
 	},
 	"formatter": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
 		"biome:lint": "biome lint --write",
 		"biome:check": "biome check --write",
 		"format": "biome format --write",
-		"typecheck": "tsc --noEmit",
+		"typecheck": "tsc --noEmit -p tsconfig.test.json",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage"

--- a/src/components/ControlFocusStyle.tsx
+++ b/src/components/ControlFocusStyle.tsx
@@ -1,0 +1,21 @@
+/**
+ * Single source of truth for the keyboard focus ring shared by every
+ * `.rqs-control` button: on-off, torch, zoom (rendered inside Finder) and the
+ * status-overlay retry control (rendered independently of Finder).
+ *
+ * Inline styles can't express `:focus-visible`, so the rule ships as a tiny
+ * stylesheet rendered next to whichever control surface is mounted. Centralising
+ * it here keeps the rule from diverging across components, and because CSS is
+ * idempotent, rendering it from more than one place at once (e.g. Finder and the
+ * status overlay together) is harmless.
+ *
+ * Internal only — intentionally NOT re-exported from `src/index.ts`. SSR-safe
+ * (renders `<style>` in JSX, no `document`/`window`) and StrictMode-safe
+ * (stateless, no effects).
+ */
+export const CONTROL_FOCUS_CSS =
+	'.rqs-control:focus-visible{outline:2px solid #fff;outline-offset:2px;border-radius:6px;}';
+
+export default function ControlFocusStyle() {
+	return <style>{CONTROL_FOCUS_CSS}</style>;
+}

--- a/src/components/Finder.tsx
+++ b/src/components/Finder.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react';
 
+import ControlFocusStyle from './ControlFocusStyle';
 import OnOff from './OnOff';
 import Torch from './Torch';
 import Zoom from './Zoom';
@@ -7,13 +8,6 @@ import Zoom from './Zoom';
 const DEFAULT_COLOR = '#ef4444';
 const DEFAULT_SIZE = '70%';
 const DEFAULT_RADIUS = '0.5rem';
-
-/**
- * Focus ring for the control buttons (torch/zoom/on-off). Inline styles can't
- * express `:focus-visible`, so the rule ships as a tiny stylesheet rendered with
- * the overlay. Duplicate identical rules across instances is harmless.
- */
-const CONTROL_FOCUS_CSS = `.rqs-control:focus-visible{outline:2px solid #fff;outline-offset:2px;border-radius:6px;}`;
 
 const fullContainer: CSSProperties = {
 	width: '100%',
@@ -97,7 +91,7 @@ export default function Finder(props: IFinderProps) {
 
 	return (
 		<div style={fullContainer}>
-			<style>{CONTROL_FOCUS_CSS}</style>
+			<ControlFocusStyle />
 			<div style={innerContainer}>
 				<div style={overlay}>
 					<div style={borderBox}>

--- a/src/components/Finder.tsx
+++ b/src/components/Finder.tsx
@@ -4,92 +4,61 @@ import OnOff from './OnOff';
 import Torch from './Torch';
 import Zoom from './Zoom';
 
-const styles: Record<string, CSSProperties> = {
-	fullContainer: {
-		width: '100%',
-		height: '100%',
-		position: 'relative',
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'center',
-		overflow: 'hidden',
-	},
-	innerContainer: {
-		width: '100%',
-		height: '100%',
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'center',
-		position: 'relative',
-	},
-	overlay: {
-		position: 'absolute',
-		top: 0,
-		right: 0,
-		bottom: 0,
-		left: 0,
-		pointerEvents: 'none',
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'center',
-	},
-	borderBox: {
-		position: 'relative',
-		width: '70%',
-		aspectRatio: '1 / 1',
-		border: '2px dashed rgba(239, 68, 68, 0.4)',
-		borderRadius: '0.5rem',
-	},
-	cornerTopLeft: {
-		position: 'absolute',
-		width: '15%',
-		height: '15%',
-		border: '4px solid #ef4444',
-		top: 0,
-		left: 0,
-		borderBottomColor: 'transparent',
-		borderRightColor: 'transparent',
-		borderTopLeftRadius: '0.5rem',
-	},
-	cornerTopRight: {
-		position: 'absolute',
-		width: '15%',
-		height: '15%',
-		border: '4px solid #ef4444',
-		top: 0,
-		right: 0,
-		borderBottomColor: 'transparent',
-		borderLeftColor: 'transparent',
-		borderTopRightRadius: '0.5rem',
-	},
-	cornerBottomLeft: {
-		position: 'absolute',
-		width: '15%',
-		height: '15%',
-		border: '4px solid #ef4444',
-		bottom: 0,
-		left: 0,
-		borderTopColor: 'transparent',
-		borderRightColor: 'transparent',
-		borderBottomLeftRadius: '0.5rem',
-	},
-	cornerBottomRight: {
-		position: 'absolute',
-		width: '15%',
-		height: '15%',
-		border: '4px solid #ef4444',
-		bottom: 0,
-		right: 0,
-		borderTopColor: 'transparent',
-		borderLeftColor: 'transparent',
-		borderBottomRightRadius: '0.5rem',
-	},
+const DEFAULT_COLOR = '#ef4444';
+const DEFAULT_SIZE = '70%';
+const DEFAULT_RADIUS = '0.5rem';
+
+/**
+ * Focus ring for the control buttons (torch/zoom/on-off). Inline styles can't
+ * express `:focus-visible`, so the rule ships as a tiny stylesheet rendered with
+ * the overlay. Duplicate identical rules across instances is harmless.
+ */
+const CONTROL_FOCUS_CSS = `.rqs-control:focus-visible{outline:2px solid #fff;outline-offset:2px;border-radius:6px;}`;
+
+const fullContainer: CSSProperties = {
+	width: '100%',
+	height: '100%',
+	position: 'relative',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	overflow: 'hidden',
 };
 
-interface IFinderProps {
+const innerContainer: CSSProperties = {
+	width: '100%',
+	height: '100%',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	position: 'relative',
+};
+
+const overlay: CSSProperties = {
+	position: 'absolute',
+	top: 0,
+	right: 0,
+	bottom: 0,
+	left: 0,
+	pointerEvents: 'none',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+};
+
+const cornerBase: CSSProperties = {
+	position: 'absolute',
+	width: '15%',
+	height: '15%',
+};
+
+export interface IFinderProps {
 	scanning: boolean;
 	capabilities: MediaTrackCapabilities;
 	onOff?: boolean;
+	color?: string;
+	size?: string;
+	borderRadius?: string;
 	startScanning: (deviceId?: string | undefined) => void;
 	stopScanning: () => void;
 	torch?: {
@@ -109,19 +78,69 @@ export default function Finder(props: IFinderProps) {
 		onOff,
 		torch,
 		zoom,
+		color = DEFAULT_COLOR,
+		size = DEFAULT_SIZE,
+		borderRadius = DEFAULT_RADIUS,
 		startScanning,
 		stopScanning,
 	} = props;
 
+	const borderBox: CSSProperties = {
+		position: 'relative',
+		width: size,
+		aspectRatio: '1 / 1',
+		border: `2px dashed ${color}66`,
+		borderRadius,
+	};
+
+	const corner = `4px solid ${color}`;
+
 	return (
-		<div style={styles.fullContainer}>
-			<div style={styles.innerContainer}>
-				<div style={styles.overlay}>
-					<div style={styles.borderBox}>
-						<div style={styles.cornerTopLeft}></div>
-						<div style={styles.cornerTopRight}></div>
-						<div style={styles.cornerBottomLeft}></div>
-						<div style={styles.cornerBottomRight}></div>
+		<div style={fullContainer}>
+			<style>{CONTROL_FOCUS_CSS}</style>
+			<div style={innerContainer}>
+				<div style={overlay}>
+					<div style={borderBox}>
+						<div
+							style={{
+								...cornerBase,
+								top: 0,
+								left: 0,
+								borderTop: corner,
+								borderLeft: corner,
+								borderTopLeftRadius: borderRadius,
+							}}
+						></div>
+						<div
+							style={{
+								...cornerBase,
+								top: 0,
+								right: 0,
+								borderTop: corner,
+								borderRight: corner,
+								borderTopRightRadius: borderRadius,
+							}}
+						></div>
+						<div
+							style={{
+								...cornerBase,
+								bottom: 0,
+								left: 0,
+								borderBottom: corner,
+								borderLeft: corner,
+								borderBottomLeftRadius: borderRadius,
+							}}
+						></div>
+						<div
+							style={{
+								...cornerBase,
+								bottom: 0,
+								right: 0,
+								borderBottom: corner,
+								borderRight: corner,
+								borderBottomRightRadius: borderRadius,
+							}}
+						></div>
 					</div>
 				</div>
 				{onOff && (

--- a/src/components/OnOff.tsx
+++ b/src/components/OnOff.tsx
@@ -11,7 +11,7 @@ interface IOnOffProps {
 
 const buttonStyle: CSSProperties = {
 	bottom: 85,
-	right: 8,
+	insetInlineEnd: 8,
 	position: 'absolute',
 	zIndex: 2,
 	background: 'transparent',
@@ -61,6 +61,7 @@ export default function OnOff(props: IOnOffProps) {
 	return (
 		<button
 			type="button"
+			className="rqs-control"
 			aria-label={label}
 			aria-pressed={scanning}
 			disabled={buttonDisabled}
@@ -68,6 +69,7 @@ export default function OnOff(props: IOnOffProps) {
 			style={{
 				...buttonStyle,
 				cursor: buttonDisabled ? 'default' : 'pointer',
+				opacity: buttonDisabled ? 0.5 : 1,
 			}}
 		>
 			{scanning ? (

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -289,27 +289,29 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 
 		// Skip the mount-time fire: `isCameraActive` is `false` and capabilities
 		// are empty placeholders before the camera starts, so reporting them would
-		// be spurious. These refs let the first real change through, not the mount.
-		const cameraActiveReportedRef = useRef(false);
-		const capabilitiesReportedRef = useRef(false);
+		// be spurious. We track the last observed value (seeded with the mount
+		// value) and only fire when it actually changes. Comparing values — rather
+		// than a "has run" flag — stays correct under StrictMode's double-invoke.
+		const lastCameraActiveRef = useRef(isCameraActive);
+		const lastCapabilitiesRef = useRef(camera.capabilities);
+		const lastSettingsRef = useRef(camera.settings);
 
 		useEffect(() => {
-			if (!cameraActiveReportedRef.current) {
-				cameraActiveReportedRef.current = true;
+			if (lastCameraActiveRef.current === isCameraActive) return;
 
-				return;
-			}
-
+			lastCameraActiveRef.current = isCameraActive;
 			onCameraActiveRef.current?.(isCameraActive);
 		}, [isCameraActive]);
 
 		useEffect(() => {
-			if (!capabilitiesReportedRef.current) {
-				capabilitiesReportedRef.current = true;
-
+			if (
+				lastCapabilitiesRef.current === camera.capabilities &&
+				lastSettingsRef.current === camera.settings
+			)
 				return;
-			}
 
+			lastCapabilitiesRef.current = camera.capabilities;
+			lastSettingsRef.current = camera.settings;
 			onCapabilitiesChangeRef.current?.(camera.capabilities, camera.settings);
 		}, [camera.capabilities, camera.settings]);
 

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -14,8 +14,9 @@ import useCamera from '../hooks/useCamera';
 import useScanner from '../hooks/useScanner';
 import { defaultComponents, defaultConstraints, defaultStyles } from '../misc';
 import type {
+	ICameraCapabilities,
+	ICameraSettings,
 	IDetectedBarcode,
-	IPoint,
 	IScannerClassNames,
 	IScannerComponents,
 	IScannerError,
@@ -23,15 +24,33 @@ import type {
 	IScannerStyles,
 	TrackFunction,
 } from '../types';
+import {
+	adjustBarcodeCoordinates,
+	computeTransform,
+} from '../utilities/coordinateTransform';
 import { createScannerError } from '../utilities/createScannerError';
 import deepEqual from '../utilities/deepEqual';
 import Finder from './Finder';
+import StatusOverlay from './StatusOverlay';
 
 export interface IScannerProps {
 	/** Called when one or more barcodes are detected. */
 	onScan: (detectedCodes: IDetectedBarcode[]) => void;
 	/** Called when the scanner can't start the camera or detection fails. */
 	onError?: (error: IScannerError) => void;
+	/**
+	 * Fires on every frame that contains at least one code, before the
+	 * duplicate/`scanDelay` filtering that gates `onScan`. Useful for live
+	 * tracking, velocity metrics, or custom result filtering.
+	 */
+	onDetected?: (detectedCodes: IDetectedBarcode[]) => void;
+	/** Fires when the camera becomes active (`true`) or stops (`false`). */
+	onCameraActive?: (active: boolean) => void;
+	/** Fires when the active track's capabilities or settings change. */
+	onCapabilitiesChange?: (
+		capabilities: ICameraCapabilities,
+		settings: ICameraSettings,
+	) => void;
 	/** Media track constraints applied to the camera stream. */
 	constraints?: MediaTrackConstraints;
 	/** Barcode formats to detect. Defaults to all supported formats. */
@@ -62,22 +81,32 @@ export interface IScannerProps {
 	settleDelayMs?: number;
 }
 
-const overlayStyle: CSSProperties = {
+/**
+ * Default format list: the `barcode-detector` meta-format `'any'` matches every
+ * supported 1D/2D symbology. A module-level constant keeps the reference stable
+ * across renders when no `formats` prop is provided.
+ */
+const ALL_FORMATS: BarcodeFormat[] = ['any'];
+
+const ABSOLUTE_OVERLAY: CSSProperties = {
 	position: 'absolute',
 	width: '100%',
 	height: '100%',
 };
 
-const pauseFrameStyleBase: CSSProperties = {
-	position: 'absolute',
-	width: '100%',
-	height: '100%',
-};
+const trackingLayerStyle = ABSOLUTE_OVERLAY;
 
-const trackingLayerStyle: CSSProperties = {
+/** Off-screen but readable by assistive technology (screen-reader only). */
+const visuallyHiddenStyle: CSSProperties = {
 	position: 'absolute',
-	width: '100%',
-	height: '100%',
+	width: 1,
+	height: 1,
+	padding: 0,
+	margin: -1,
+	overflow: 'hidden',
+	clip: 'rect(0, 0, 0, 0)',
+	whiteSpace: 'nowrap',
+	border: 0,
 };
 
 function clearCanvas(canvas: HTMLCanvasElement | null) {
@@ -115,43 +144,16 @@ function drawTracking(
 		return;
 	}
 
-	const largerRatio = Math.max(
-		displayWidth / resolutionWidth,
-		displayHeight / resolutionHeight,
+	const transform = computeTransform({
+		displayWidth,
+		displayHeight,
+		resolutionWidth,
+		resolutionHeight,
+	});
+
+	const adjustedCodes = detectedCodes.map((detectedCode) =>
+		adjustBarcodeCoordinates(detectedCode, transform),
 	);
-	const uncutWidth = resolutionWidth * largerRatio;
-	const uncutHeight = resolutionHeight * largerRatio;
-
-	const xScalar = uncutWidth / resolutionWidth;
-	const yScalar = uncutHeight / resolutionHeight;
-	const xOffset = (displayWidth - uncutWidth) / 2;
-	const yOffset = (displayHeight - uncutHeight) / 2;
-
-	const scale = ({ x, y }: IPoint): IPoint => ({
-		x: Math.floor(x * xScalar),
-		y: Math.floor(y * yScalar),
-	});
-
-	const translate = ({ x, y }: IPoint): IPoint => ({
-		x: Math.floor(x + xOffset),
-		y: Math.floor(y + yOffset),
-	});
-
-	const adjustedCodes = detectedCodes.map((detectedCode) => {
-		const { boundingBox, cornerPoints } = detectedCode;
-
-		const { x, y } = translate(scale({ x: boundingBox.x, y: boundingBox.y }));
-		const { x: width, y: height } = scale({
-			x: boundingBox.width,
-			y: boundingBox.height,
-		});
-
-		return {
-			...detectedCode,
-			cornerPoints: cornerPoints.map((point) => translate(scale(point))),
-			boundingBox: DOMRectReadOnly.fromRect({ x, y, width, height }),
-		};
-	});
 
 	trackingEl.width = displayWidth;
 	trackingEl.height = displayHeight;
@@ -167,7 +169,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 		const {
 			onScan,
 			constraints,
-			formats = ['any' as BarcodeFormat],
+			formats = ALL_FORMATS,
 			paused = false,
 			components,
 			tracker: trackerProp,
@@ -178,6 +180,9 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 			scanDelay,
 			retryDelay,
 			onError,
+			onDetected,
+			onCameraActive,
+			onCapabilitiesChange,
 			sound,
 			startTimeoutMs,
 			settleDelayMs,
@@ -186,6 +191,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 		const videoRef = useRef<HTMLVideoElement>(null);
 		const pauseFrameRef = useRef<HTMLCanvasElement>(null);
 		const trackingLayerRef = useRef<HTMLCanvasElement>(null);
+		const liveRegionRef = useRef<HTMLDivElement>(null);
 
 		// Normalize once: when a deviceId is present, the default `facingMode`
 		// is stripped so the comparison below has a stable shape. Doing this
@@ -213,8 +219,18 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 
 		const effectiveTracker = trackerProp ?? mergedComponents.tracker;
 
+		// `finder` may be a boolean or a theming config; normalize both.
+		const showFinder = Boolean(mergedComponents.finder);
+		const finderConfig =
+			typeof mergedComponents.finder === 'object'
+				? mergedComponents.finder
+				: undefined;
+
 		const [isMounted, setIsMounted] = useState(false);
 		const [isCameraActive, setIsCameraActive] = useState(false);
+		const [scannerError, setScannerError] = useState<IScannerError | null>(
+			null,
+		);
 		const [constraintsCached, setConstraintsCached] = useState(
 			normalizedConstraints,
 		);
@@ -224,7 +240,11 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 		const cameraRef = useRef(camera);
 		const onScanRef = useRef(onScan);
 		const onErrorRef = useRef(onError);
+		const onDetectedRef = useRef(onDetected);
 		const trackerRef = useRef<TrackFunction | undefined>(effectiveTracker);
+		// Mirrors of state/derived values the imperative handle reads at call time.
+		const constraintsCachedRef = useRef(constraintsCached);
+		const isCameraActiveRef = useRef(isCameraActive);
 
 		useEffect(() => {
 			cameraRef.current = camera;
@@ -239,17 +259,65 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 		}, [onError]);
 
 		useEffect(() => {
+			onDetectedRef.current = onDetected;
+		}, [onDetected]);
+
+		useEffect(() => {
 			trackerRef.current = effectiveTracker;
 		}, [effectiveTracker]);
 
-		// Stable onScan/onFound/onError callbacks so identity churn from inline
-		// props doesn't tear down and restart the scanning loop on every render.
+		useEffect(() => {
+			constraintsCachedRef.current = constraintsCached;
+		}, [constraintsCached]);
+
+		useEffect(() => {
+			isCameraActiveRef.current = isCameraActive;
+		}, [isCameraActive]);
+
+		// Observability callbacks are read through refs (depending only on the
+		// observed value) so passing inline handlers doesn't re-fire them.
+		const onCameraActiveRef = useRef(onCameraActive);
+		const onCapabilitiesChangeRef = useRef(onCapabilitiesChange);
+
+		useEffect(() => {
+			onCameraActiveRef.current = onCameraActive;
+		}, [onCameraActive]);
+
+		useEffect(() => {
+			onCapabilitiesChangeRef.current = onCapabilitiesChange;
+		}, [onCapabilitiesChange]);
+
+		useEffect(() => {
+			onCameraActiveRef.current?.(isCameraActive);
+		}, [isCameraActive]);
+
+		useEffect(() => {
+			onCapabilitiesChangeRef.current?.(camera.capabilities, camera.settings);
+		}, [camera.capabilities, camera.settings]);
+
+		// Stable onScan/onDetected/onFound/onError callbacks so identity churn from
+		// inline props doesn't tear down and restart the scanning loop every render.
 		const stableOnScan = useCallback((codes: IDetectedBarcode[]) => {
 			onScanRef.current?.(codes);
+
+			// Announce the decoded value(s) to screen readers. Writing textContent
+			// directly (rather than via state) avoids re-rendering on every scan.
+			const region = liveRegionRef.current;
+
+			if (region !== null && codes.length > 0) {
+				region.textContent = `Detected: ${codes
+					.map((code) => code.rawValue)
+					.join(', ')}`;
+			}
 		}, []);
 
 		const stableOnError = useCallback((error: IScannerError) => {
+			setScannerError(error);
 			onErrorRef.current?.(error);
+		}, []);
+
+		const stableOnDetected = useCallback((codes: IDetectedBarcode[]) => {
+			onDetectedRef.current?.(codes);
 		}, []);
 
 		const onFoundCallback = useCallback((detectedCodes: IDetectedBarcode[]) => {
@@ -269,6 +337,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 			onScan: stableOnScan,
 			onFound: onFoundCallback,
 			onError: stableOnError,
+			onDetected: stableOnDetected,
 			formats,
 			retryDelay: effectiveRetryDelay,
 			scanDelay,
@@ -318,6 +387,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 					});
 
 					setIsCameraActive(true);
+					setScannerError(null);
 				} else {
 					if (videoEl.videoWidth > 0 && videoEl.videoHeight > 0) {
 						canvasEl.width = videoEl.videoWidth;
@@ -338,13 +408,28 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 			} catch (error) {
 				setIsCameraActive(false);
 
-				onErrorRef.current?.(createScannerError(error));
+				const scannerErr = createScannerError(error);
+				setScannerError(scannerErr);
+				onErrorRef.current?.(scannerErr);
 			}
 		}, [cameraSettings]);
+
+		const onCameraChangeRef = useRef(onCameraChange);
+
+		useEffect(() => {
+			onCameraChangeRef.current = onCameraChange;
+		}, [onCameraChange]);
 
 		useEffect(() => {
 			void onCameraChange();
 		}, [onCameraChange]);
+
+		// Recovery path for the status overlay: clear the error so the overlay
+		// flips to its loading state, then re-run the camera-start flow.
+		const handleStatusRetry = useCallback(() => {
+			setScannerError(null);
+			void onCameraChangeRef.current();
+		}, []);
 
 		const shouldScan = useMemo(() => {
 			return cameraSettings.shouldStream && isCameraActive;
@@ -367,6 +452,57 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 			() => ({
 				getVideoElement: () => videoRef.current,
 				getStream: () => cameraRef.current.getStream(),
+				getCameraState: () => ({
+					isActive: isCameraActiveRef.current,
+					capabilities: cameraRef.current.capabilities,
+					settings: cameraRef.current.settings,
+				}),
+				snapshot: async (options) => {
+					const video = videoRef.current;
+
+					if (
+						video === null ||
+						video.videoWidth === 0 ||
+						video.videoHeight === 0
+					) {
+						return null;
+					}
+
+					const canvas = document.createElement('canvas');
+					canvas.width = video.videoWidth;
+					canvas.height = video.videoHeight;
+
+					const ctx = canvas.getContext('2d');
+
+					if (ctx === null) return null;
+
+					ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+					return new Promise<Blob | null>((resolve) => {
+						canvas.toBlob(
+							(blob) => resolve(blob),
+							options?.type ?? 'image/png',
+							options?.quality,
+						);
+					});
+				},
+				toggleTorch: async (on) => {
+					const next = on ?? !(cameraRef.current.settings.torch ?? false);
+
+					await cameraRef.current.updateConstraints({
+						...constraintsCachedRef.current,
+						advanced: [{ torch: next }],
+					});
+				},
+				setZoom: async (value) => {
+					await cameraRef.current.updateConstraints({
+						...constraintsCachedRef.current,
+						advanced: [{ zoom: value }],
+					});
+				},
+				restart: async () => {
+					await onCameraChangeRef.current();
+				},
 			}),
 			[],
 		);
@@ -387,11 +523,36 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 
 		const pauseFrameStyle = useMemo<CSSProperties>(
 			() => ({
-				...pauseFrameStyleBase,
+				...ABSOLUTE_OVERLAY,
 				display: paused ? 'block' : 'none',
 			}),
 			[paused],
 		);
+
+		// Opt-in loading/error overlay. Loading = the camera should be streaming
+		// but isn't active yet and no error has surfaced.
+		const statusOverlay = mergedComponents.statusOverlay;
+		const isLoading =
+			cameraSettings.shouldStream && !isCameraActive && scannerError === null;
+
+		let statusOverlayNode: ReactNode = null;
+
+		if (statusOverlay) {
+			statusOverlayNode =
+				typeof statusOverlay === 'function' ? (
+					statusOverlay({
+						error: scannerError,
+						isLoading,
+						onRetry: handleStatusRetry,
+					})
+				) : (
+					<StatusOverlay
+						error={scannerError}
+						isLoading={isLoading}
+						onRetry={handleStatusRetry}
+					/>
+				);
+		}
 
 		return (
 			<div style={containerStyle} className={classNames?.container}>
@@ -399,18 +560,28 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 					ref={videoRef}
 					style={videoStyle}
 					className={classNames?.video}
+					aria-label="Barcode scanner camera feed"
 					autoPlay
 					muted
 					playsInline
 				/>
 				<canvas ref={pauseFrameRef} style={pauseFrameStyle} />
 				<canvas ref={trackingLayerRef} style={trackingLayerStyle} />
-				<div style={overlayStyle}>
-					{mergedComponents.finder && (
+				<div
+					ref={liveRegionRef}
+					aria-live="polite"
+					aria-atomic="true"
+					style={visuallyHiddenStyle}
+				/>
+				<div style={ABSOLUTE_OVERLAY}>
+					{showFinder && (
 						<Finder
 							scanning={isCameraActive}
 							capabilities={camera.capabilities}
 							onOff={mergedComponents.onOff}
+							color={finderConfig?.color}
+							size={finderConfig?.size}
+							borderRadius={finderConfig?.borderRadius}
 							zoom={
 								mergedComponents.zoom && camera.settings.zoom
 									? {
@@ -459,6 +630,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 					)}
 					{children}
 				</div>
+				{statusOverlayNode}
 			</div>
 		);
 	},

--- a/src/components/Scanner.tsx
+++ b/src/components/Scanner.tsx
@@ -104,7 +104,7 @@ const visuallyHiddenStyle: CSSProperties = {
 	padding: 0,
 	margin: -1,
 	overflow: 'hidden',
-	clip: 'rect(0, 0, 0, 0)',
+	clipPath: 'inset(50%)',
 	whiteSpace: 'nowrap',
 	border: 0,
 };
@@ -275,7 +275,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 		}, [isCameraActive]);
 
 		// Observability callbacks are read through refs (depending only on the
-		// observed value) so passing inline handlers doesn't re-fire them.
+		// observed value), so passing inline handlers doesn't re-fire them.
 		const onCameraActiveRef = useRef(onCameraActive);
 		const onCapabilitiesChangeRef = useRef(onCapabilitiesChange);
 
@@ -287,11 +287,29 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 			onCapabilitiesChangeRef.current = onCapabilitiesChange;
 		}, [onCapabilitiesChange]);
 
+		// Skip the mount-time fire: `isCameraActive` is `false` and capabilities
+		// are empty placeholders before the camera starts, so reporting them would
+		// be spurious. These refs let the first real change through, not the mount.
+		const cameraActiveReportedRef = useRef(false);
+		const capabilitiesReportedRef = useRef(false);
+
 		useEffect(() => {
+			if (!cameraActiveReportedRef.current) {
+				cameraActiveReportedRef.current = true;
+
+				return;
+			}
+
 			onCameraActiveRef.current?.(isCameraActive);
 		}, [isCameraActive]);
 
 		useEffect(() => {
+			if (!capabilitiesReportedRef.current) {
+				capabilitiesReportedRef.current = true;
+
+				return;
+			}
+
 			onCapabilitiesChangeRef.current?.(camera.capabilities, camera.settings);
 		}, [camera.capabilities, camera.settings]);
 
@@ -530,7 +548,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 		);
 
 		// Opt-in loading/error overlay. Loading = the camera should be streaming
-		// but isn't active yet and no error has surfaced.
+		// but isn't active yet, and no error has surfaced.
 		const statusOverlay = mergedComponents.statusOverlay;
 		const isLoading =
 			cameraSettings.shouldStream && !isCameraActive && scannerError === null;
@@ -620,6 +638,7 @@ export const Scanner = forwardRef<IScannerHandle, IScannerProps>(
 							stopScanning={async () => {
 								try {
 									await camera.stopCamera();
+
 									clearCanvas(trackingLayerRef.current);
 									setIsCameraActive(false);
 								} catch (error) {

--- a/src/components/StatusOverlay.tsx
+++ b/src/components/StatusOverlay.tsx
@@ -1,6 +1,5 @@
 import type { CSSProperties } from 'react';
-import type { ScannerErrorKind } from '../types';
-import type { IStatusOverlayState } from '../types/IStatusOverlayState';
+import type { IStatusOverlayState, ScannerErrorKind } from '../types';
 
 const ERROR_MESSAGES: Record<ScannerErrorKind, string> = {
 	'permission-denied': 'Camera access was denied. Please allow it and retry.',
@@ -27,7 +26,7 @@ const containerStyle: CSSProperties = {
 	inset: 0,
 	zIndex: 3,
 	// The backdrop is passive feedback, not a modal. Letting clicks pass through
-	// keeps the controls beneath (on/off, torch, zoom) reachable; interactive
+	// keeps the controls beneath (on/off, torch, zoom) reachable; the interactive
 	// children below opt back in with `pointerEvents: 'auto'`.
 	pointerEvents: 'none',
 	display: 'flex',
@@ -71,12 +70,14 @@ const spinnerStyle: CSSProperties = {
 	borderRadius: '50%',
 	border: '3px solid rgba(255, 255, 255, 0.35)',
 	borderTopColor: '#fff',
-	animation: 'rqs-spin 0.8s linear infinite',
+	// animation is intentionally omitted here; it is applied via the
+	// .rqs-spinner class so the prefers-reduced-motion media query can
+	// override it (inline styles have higher specificity than class rules).
 };
 
-// Keyframes can't live in inline styles; the spinner animation respects
-// reduced-motion preferences by pausing the rotation.
-const SPINNER_CSS = `@keyframes rqs-spin{to{transform:rotate(360deg)}}@media (prefers-reduced-motion: reduce){.rqs-spinner{animation:none}}`;
+// Keyframes can't live in inline styles, and the animation is assigned via the
+// .rqs-spinner class (not inline), so the reduced-motion query can disable it.
+const SPINNER_CSS = `@keyframes rqs-spin{to{transform:rotate(360deg)}}.rqs-spinner{animation:rqs-spin 0.8s linear infinite}@media (prefers-reduced-motion: reduce){.rqs-spinner{animation:none}}`;
 
 /**
  * Built-in loading / error overlay. Enabled via `components.statusOverlay`.

--- a/src/components/StatusOverlay.tsx
+++ b/src/components/StatusOverlay.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties } from 'react';
 import type { IStatusOverlayState, ScannerErrorKind } from '../types';
+import ControlFocusStyle from './ControlFocusStyle';
 
 const ERROR_MESSAGES: Record<ScannerErrorKind, string> = {
 	'permission-denied': 'Camera access was denied. Please allow it and retry.',
@@ -91,6 +92,7 @@ export default function StatusOverlay(props: IStatusOverlayState) {
 
 		return (
 			<div style={containerStyle} role="alert">
+				<ControlFocusStyle />
 				<div style={errorContentStyle}>
 					<span>{ERROR_MESSAGES[error.kind] ?? error.message}</span>
 					{canRetry && (

--- a/src/components/StatusOverlay.tsx
+++ b/src/components/StatusOverlay.tsx
@@ -1,0 +1,123 @@
+import type { CSSProperties } from 'react';
+import type { ScannerErrorKind } from '../types';
+import type { IStatusOverlayState } from '../types/IStatusOverlayState';
+
+const ERROR_MESSAGES: Record<ScannerErrorKind, string> = {
+	'permission-denied': 'Camera access was denied. Please allow it and retry.',
+	'no-camera': 'No camera was found on this device.',
+	'in-use': 'The camera is being used by another application.',
+	overconstrained: "The requested camera settings aren't supported.",
+	'insecure-context': 'Camera access requires a secure (HTTPS) connection.',
+	unsupported: "This browser doesn't support camera access.",
+	aborted: 'The camera request was interrupted. Please retry.',
+	security: 'Camera access was blocked for security reasons.',
+	'type-error': 'The camera could not be started.',
+	unknown: 'Something went wrong while accessing the camera.',
+};
+
+// Errors a retry can never resolve: a missing secure context needs an HTTPS
+// reload, and an unsupported browser won't gain support by trying again.
+const NON_RETRYABLE: ReadonlySet<ScannerErrorKind> = new Set([
+	'insecure-context',
+	'unsupported',
+]);
+
+const containerStyle: CSSProperties = {
+	position: 'absolute',
+	inset: 0,
+	zIndex: 3,
+	// The backdrop is passive feedback, not a modal. Letting clicks pass through
+	// keeps the controls beneath (on/off, torch, zoom) reachable; interactive
+	// children below opt back in with `pointerEvents: 'auto'`.
+	pointerEvents: 'none',
+	display: 'flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	textAlign: 'center',
+	padding: 16,
+	color: '#fff',
+	background: 'rgba(0, 0, 0, 0.6)',
+	font: '500 14px/1.4 system-ui, sans-serif',
+};
+
+const errorContentStyle: CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'center',
+	gap: 12,
+};
+
+const retryButtonStyle: CSSProperties = {
+	pointerEvents: 'auto',
+	cursor: 'pointer',
+	padding: '8px 16px',
+	borderRadius: 6,
+	border: '1px solid rgba(255, 255, 255, 0.6)',
+	background: 'rgba(255, 255, 255, 0.12)',
+	color: '#fff',
+	font: 'inherit',
+};
+
+const loadingContentStyle: CSSProperties = {
+	display: 'flex',
+	flexDirection: 'column',
+	alignItems: 'center',
+};
+
+const spinnerStyle: CSSProperties = {
+	width: 28,
+	height: 28,
+	marginBottom: 12,
+	borderRadius: '50%',
+	border: '3px solid rgba(255, 255, 255, 0.35)',
+	borderTopColor: '#fff',
+	animation: 'rqs-spin 0.8s linear infinite',
+};
+
+// Keyframes can't live in inline styles; the spinner animation respects
+// reduced-motion preferences by pausing the rotation.
+const SPINNER_CSS = `@keyframes rqs-spin{to{transform:rotate(360deg)}}@media (prefers-reduced-motion: reduce){.rqs-spinner{animation:none}}`;
+
+/**
+ * Built-in loading / error overlay. Enabled via `components.statusOverlay`.
+ * Maps an {@link IStatusOverlayState} to accessible, human-readable feedback.
+ */
+export default function StatusOverlay(props: IStatusOverlayState) {
+	const { error, isLoading, onRetry } = props;
+
+	if (error !== null) {
+		const canRetry = onRetry !== undefined && !NON_RETRYABLE.has(error.kind);
+
+		return (
+			<div style={containerStyle} role="alert">
+				<div style={errorContentStyle}>
+					<span>{ERROR_MESSAGES[error.kind] ?? error.message}</span>
+					{canRetry && (
+						<button
+							type="button"
+							className="rqs-control"
+							style={retryButtonStyle}
+							onClick={() => onRetry?.()}
+						>
+							Retry
+						</button>
+					)}
+				</div>
+			</div>
+		);
+	}
+
+	if (isLoading) {
+		return (
+			<div style={containerStyle} role="status">
+				<style>{SPINNER_CSS}</style>
+				<div style={loadingContentStyle}>
+					<div className="rqs-spinner" style={spinnerStyle} />
+					<span>Starting camera…</span>
+				</div>
+			</div>
+		);
+	}
+
+	return null;
+}

--- a/src/components/Torch.tsx
+++ b/src/components/Torch.tsx
@@ -11,7 +11,7 @@ interface ITorchProps {
 
 const buttonStyle: CSSProperties = {
 	bottom: 35,
-	right: 8,
+	insetInlineEnd: 8,
 	position: 'absolute',
 	zIndex: 2,
 	background: 'transparent',
@@ -34,6 +34,7 @@ export default function Torch(props: ITorchProps) {
 	return (
 		<button
 			type="button"
+			className="rqs-control"
 			aria-label={label}
 			aria-pressed={status}
 			onClick={() => torchToggle(!status)}

--- a/src/components/Zoom.tsx
+++ b/src/components/Zoom.tsx
@@ -12,7 +12,7 @@ interface IZoomProps {
 
 const zoomOutButtonStyle: CSSProperties = {
 	bottom: 130,
-	right: 8,
+	insetInlineEnd: 8,
 	position: 'absolute',
 	zIndex: 2,
 	background: 'transparent',
@@ -52,24 +52,28 @@ export default function Zoom(props: IZoomProps) {
 		<Fragment>
 			<button
 				type="button"
+				className="rqs-control"
 				aria-label="Zoom out"
 				disabled={atMin}
 				onClick={handleZoomOut}
 				style={{
 					...zoomOutButtonStyle,
 					cursor: atMin ? 'default' : 'pointer',
+					opacity: atMin ? 0.5 : 1,
 				}}
 			>
 				<ZoomOutIcon disabled={atMin} />
 			</button>
 			<button
 				type="button"
+				className="rqs-control"
 				aria-label="Zoom in"
 				disabled={atMax}
 				onClick={handleZoomIn}
 				style={{
 					...zoomInButtonStyle,
 					cursor: atMax ? 'default' : 'pointer',
+					opacity: atMax ? 0.5 : 1,
 				}}
 			>
 				<ZoomInIcon disabled={atMax} />

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -2,7 +2,8 @@ import 'webrtc-adapter';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import type { IStartCamera, IStartTaskResult, IStopTaskResult } from '../types';
+import type { IStartCamera } from '../types';
+import type { IStartTaskResult, IStopTaskResult } from '../types/internal';
 
 type TaskResult = IStartTaskResult | IStopTaskResult;
 

--- a/src/hooks/useCamera.ts
+++ b/src/hooks/useCamera.ts
@@ -118,6 +118,7 @@ export default function useCamera(options: IUseCameraOptions = {}) {
 			currentVideoTrack.current = null;
 
 			setSettings({});
+			setCapabilities({});
 
 			return { type: 'stop', data: {} };
 		},

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -5,14 +5,18 @@ import {
 } from 'barcode-detector/ponyfill';
 import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
 import { base64Beep } from '../assets/base64Beep';
-import type { IScannerError, IUseScannerState } from '../types';
+import type { IScannerError } from '../types';
+import type { IUseScannerState } from '../types/internal';
 import { createScannerError } from '../utilities/createScannerError';
 
-interface IUseScannerProps {
+export interface IUseScannerProps {
 	videoElementRef: RefObject<HTMLVideoElement | null>;
 	onScan: (result: DetectedBarcode[]) => void;
 	onFound: (result: DetectedBarcode[]) => void;
 	onError?: (error: IScannerError) => void;
+	/** Fires on every frame that contains at least one code, before the
+	 * duplicate/`scanDelay` filtering that gates `onScan`. */
+	onDetected?: (result: DetectedBarcode[]) => void;
 	formats?: BarcodeFormat[];
 	sound?: boolean | string;
 	allowMultiple?: boolean;
@@ -22,12 +26,40 @@ interface IUseScannerProps {
 
 const EMPTY_FORMATS: BarcodeFormat[] = [];
 
+interface IFrameHandle {
+	cancel: () => void;
+}
+
+/**
+ * Schedules a detection callback on the next *video* frame using
+ * `requestVideoFrameCallback` when available — it fires only when a new frame is
+ * actually presented, so we don't run the detector on duplicate frames (fewer
+ * WASM calls, less battery). Falls back to `requestAnimationFrame` otherwise.
+ */
+function scheduleFrame(
+	video: HTMLVideoElement | null,
+	callback: (time: number) => void,
+): IFrameHandle | null {
+	if (typeof window === 'undefined') return null;
+
+	if (video && typeof video.requestVideoFrameCallback === 'function') {
+		const id = video.requestVideoFrameCallback(callback);
+
+		return { cancel: () => video.cancelVideoFrameCallback(id) };
+	}
+
+	const id = window.requestAnimationFrame(callback);
+
+	return { cancel: () => window.cancelAnimationFrame(id) };
+}
+
 export default function useScanner(props: IUseScannerProps) {
 	const {
 		videoElementRef,
 		onScan,
 		onFound,
 		onError,
+		onDetected,
 		retryDelay = 100,
 		scanDelay = 0,
 		formats = EMPTY_FORMATS,
@@ -41,12 +73,12 @@ export default function useScanner(props: IUseScannerProps) {
 
 	const barcodeDetectorRef = useRef<BarcodeDetector | null>(null);
 	const audioRef = useRef<HTMLAudioElement | null>(null);
-	const animationFrameIdRef = useRef<number | null>(null);
+	const frameHandleRef = useRef<IFrameHandle | null>(null);
 
-	if (typeof window !== 'undefined' && barcodeDetectorRef.current === null) {
-		barcodeDetectorRef.current = new BarcodeDetector({ formats });
-	}
-
+	// The detector is (re)built only in this effect — never during render — so a
+	// transient render (Suspense/StrictMode/error boundary) can't spawn stray
+	// instances. It is created before scanning starts, since startScanning only
+	// runs once the camera is active, well after mount effects have flushed.
 	// biome-ignore lint/correctness/useExhaustiveDependencies: formatsKey is the stable identity for `formats`
 	useEffect(() => {
 		if (typeof window === 'undefined') return;
@@ -61,12 +93,44 @@ export default function useScanner(props: IUseScannerProps) {
 			return;
 		}
 
-		audioRef.current = new Audio(
-			typeof sound === 'string' ? sound : base64Beep,
-		);
+		const audio = new Audio(typeof sound === 'string' ? sound : base64Beep);
+		audioRef.current = audio;
+
+		// iOS/Safari block audio until a user gesture. Prime the element silently
+		// on the first interaction so the first successful scan isn't muted.
+		const gestureEvents = ['pointerdown', 'keydown', 'touchstart'] as const;
+
+		const removeUnlock = () => {
+			for (const event of gestureEvents) {
+				window.removeEventListener(event, unlock);
+			}
+		};
+
+		const unlock = () => {
+			const wasMuted = audio.muted;
+			audio.muted = true;
+
+			audio
+				.play()
+				.then(() => {
+					audio.pause();
+					audio.currentTime = 0;
+					audio.muted = wasMuted;
+				})
+				.catch(() => {
+					audio.muted = wasMuted;
+				});
+
+			removeUnlock();
+		};
+
+		for (const event of gestureEvents) {
+			window.addEventListener(event, unlock);
+		}
 
 		return () => {
-			audioRef.current?.pause();
+			removeUnlock();
+			audio.pause();
 			audioRef.current = null;
 		};
 	}, [sound]);
@@ -83,10 +147,23 @@ export default function useScanner(props: IUseScannerProps) {
 				return;
 			}
 
+			// Pause detection while the page is hidden. The reschedule won't fire
+			// until the page is visible again (rAF/rVFC are paused in background
+			// tabs), so this idles cleanly instead of detecting off-screen.
+			if (typeof document !== 'undefined' && document.hidden) {
+				frameHandleRef.current = scheduleFrame(
+					videoElementRef.current,
+					processFrame(state),
+				);
+
+				return;
+			}
+
 			const { lastScan, contentBefore, lastScanHadContent } = state;
 
 			if (timeNow - lastScan < retryDelay) {
-				animationFrameIdRef.current = window.requestAnimationFrame(
+				frameHandleRef.current = scheduleFrame(
+					videoElementRef.current,
 					processFrame(state),
 				);
 
@@ -112,6 +189,12 @@ export default function useScanner(props: IUseScannerProps) {
 			);
 
 			const currentScanHasContent = detectedCodes.length > 0;
+
+			// Raw per-frame stream: fires whenever codes are present, ahead of the
+			// duplicate/scanDelay gating applied to onScan below.
+			if (currentScanHasContent) {
+				onDetected?.(detectedCodes);
+			}
 
 			let lastOnScan = state.lastOnScan;
 			const scanDelayPassed = timeNow - lastOnScan >= scanDelay;
@@ -145,11 +228,21 @@ export default function useScanner(props: IUseScannerProps) {
 				contentBefore: newContentBefore,
 			};
 
-			animationFrameIdRef.current = window.requestAnimationFrame(
+			frameHandleRef.current = scheduleFrame(
+				videoElementRef.current,
 				processFrame(newState),
 			);
 		},
-		[onScan, onFound, onError, retryDelay, allowMultiple, scanDelay, sound],
+		[
+			onScan,
+			onFound,
+			onError,
+			onDetected,
+			retryDelay,
+			allowMultiple,
+			scanDelay,
+			sound,
+		],
 	);
 
 	const startScanning = useCallback(() => {
@@ -164,16 +257,15 @@ export default function useScanner(props: IUseScannerProps) {
 			lastScanHadContent: false,
 		};
 
-		animationFrameIdRef.current = window.requestAnimationFrame(
+		frameHandleRef.current = scheduleFrame(
+			videoElementRef.current,
 			processFrame(initialState),
 		);
-	}, [processFrame]);
+	}, [processFrame, videoElementRef]);
 
 	const stopScanning = useCallback(() => {
-		if (animationFrameIdRef.current !== null) {
-			window.cancelAnimationFrame(animationFrameIdRef.current);
-			animationFrameIdRef.current = null;
-		}
+		frameHandleRef.current?.cancel();
+		frameHandleRef.current = null;
 	}, []);
 
 	return {

--- a/src/hooks/useScanner.ts
+++ b/src/hooks/useScanner.ts
@@ -139,11 +139,25 @@ export default function useScanner(props: IUseScannerProps) {
 	const processFrame = useCallback(
 		(state: IUseScannerState) => async (timeNow: number) => {
 			const detector = barcodeDetectorRef.current;
-			if (
-				videoElementRef.current === null ||
-				videoElementRef.current.readyState <= 1 ||
-				detector === null
-			) {
+
+			// Element unmounted — the only terminal case. There's no video to
+			// reschedule against, so stop the loop here.
+			if (videoElementRef.current === null) {
+				return;
+			}
+
+			// Not yet ready (HAVE_NOTHING/HAVE_METADATA) or the detector hasn't
+			// been built. Both are transient — a brief buffer stall or
+			// constraint re-negotiation can drop readyState to 1. rVFC only
+			// fires on a newly presented frame, so returning without
+			// re-registering would freeze the loop while the camera stays live.
+			// Reschedule and retry instead.
+			if (videoElementRef.current.readyState <= 1 || detector === null) {
+				frameHandleRef.current = scheduleFrame(
+					videoElementRef.current,
+					processFrame(state),
+				);
+
 				return;
 			}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,15 @@ export {
 	setZXingModuleOverrides,
 } from 'barcode-detector/ponyfill';
 export * from './components/Scanner';
+export {
+	default as useCamera,
+	type IUseCameraOptions,
+} from './hooks/useCamera';
 export * from './hooks/useDevices';
+export {
+	default as useScanner,
+	type IUseScannerProps,
+} from './hooks/useScanner';
 export * from './misc/overlays';
 export * from './types';
 export { createScannerError } from './utilities/createScannerError';

--- a/src/types/ICameraCapabilities.ts
+++ b/src/types/ICameraCapabilities.ts
@@ -1,0 +1,16 @@
+/**
+ * Camera track capabilities, including the non-standard `torch`/`zoom` that the
+ * Barcode/MediaStream specs don't type. Exposed explicitly (rather than via the
+ * library's internal global augmentation), so consumers of `getCameraState()` and
+ * `onCapabilitiesChange` get these typed without extra setup.
+ */
+export interface ICameraCapabilities extends MediaTrackCapabilities {
+	torch?: boolean;
+	zoom?: { min: number; max: number; step: number };
+}
+
+/** Camera track settings, including the non-standard `torch`/`zoom`. */
+export interface ICameraSettings extends MediaTrackSettings {
+	torch?: boolean;
+	zoom?: number;
+}

--- a/src/types/IFinderConfig.ts
+++ b/src/types/IFinderConfig.ts
@@ -1,0 +1,9 @@
+/** Theming options for the built-in finder overlay. */
+export interface IFinderConfig {
+	/** Stroke color of the finder corners and dashed box. Default `#ef4444`. */
+	color?: string;
+	/** Box size as a CSS dimension, e.g. `'70%'` or `'240px'`. Default `'70%'`. */
+	size?: string;
+	/** Border radius of the finder box. Default `'0.5rem'`. */
+	borderRadius?: string;
+}

--- a/src/types/IScannerComponents.ts
+++ b/src/types/IScannerComponents.ts
@@ -1,9 +1,23 @@
-import type { TrackFunction } from './index';
+import type { ReactNode } from 'react';
+import type {
+	IFinderConfig,
+	IStatusOverlayState,
+	TrackFunction,
+} from './index';
 
 export interface IScannerComponents {
-	finder?: boolean;
+	/**
+	 * Show the built-in finder overlay. Pass an {@link IFinderConfig} object to
+	 * theme its color, size, and border radius instead of just `true`.
+	 */
+	finder?: boolean | IFinderConfig;
 	torch?: boolean;
 	tracker?: TrackFunction;
 	onOff?: boolean;
 	zoom?: boolean;
+	/**
+	 * Show a built-in loading/error overlay. Pass `true` for the default UI, or
+	 * a render function to fully customize it from the current overlay state.
+	 */
+	statusOverlay?: boolean | ((state: IStatusOverlayState) => ReactNode);
 }

--- a/src/types/IScannerHandle.ts
+++ b/src/types/IScannerHandle.ts
@@ -1,4 +1,39 @@
+import type {
+	ICameraCapabilities,
+	ICameraSettings,
+} from './ICameraCapabilities';
+
+/** Options for capturing a still frame via {@link IScannerHandle.snapshot}. */
+export interface ISnapshotOptions {
+	/** Image MIME type, e.g. `'image/png'` (default) or `'image/jpeg'`. */
+	type?: string;
+	/** Quality 0–1 for lossy types like `'image/jpeg'`. */
+	quality?: number;
+}
+
+/** A snapshot of camera activity, capabilities, and track settings. */
+export interface ICameraState {
+	isActive: boolean;
+	capabilities: ICameraCapabilities;
+	settings: ICameraSettings;
+}
+
 export interface IScannerHandle {
+	/** The underlying `<video>` element, or `null` before mount / after unmount. */
 	getVideoElement: () => HTMLVideoElement | null;
+	/** The active `MediaStream`, or `null` when the camera is stopped. */
 	getStream: () => MediaStream | null;
+	/** Reads camera activity, capabilities, and track settings at call time. */
+	getCameraState: () => ICameraState;
+	/**
+	 * Captures the current video frame as a `Blob`. Resolves to `null` if no
+	 * frame is available yet (camera not started / no dimensions).
+	 */
+	snapshot: (options?: ISnapshotOptions) => Promise<Blob | null>;
+	/** Toggles the torch (flashlight); pass a boolean to set it explicitly. */
+	toggleTorch: (on?: boolean) => Promise<void>;
+	/** Sets the zoom level (the device clamps it to its supported range). */
+	setZoom: (value: number) => Promise<void>;
+	/** Stops and restarts the camera with the current constraints. */
+	restart: () => Promise<void>;
 }

--- a/src/types/IStartTaskResult.ts
+++ b/src/types/IStartTaskResult.ts
@@ -1,8 +1,0 @@
-export interface IStartTaskResult {
-	type: 'start';
-	data: {
-		videoEl: HTMLVideoElement;
-		stream: MediaStream;
-		constraints: MediaTrackConstraints;
-	};
-}

--- a/src/types/IStatusOverlayState.ts
+++ b/src/types/IStatusOverlayState.ts
@@ -1,0 +1,14 @@
+import type { IScannerError } from './IScannerError';
+
+/** State passed to a custom `components.statusOverlay` render function. */
+export interface IStatusOverlayState {
+	/** The most recent camera/detection error, or `null` if there is none. */
+	error: IScannerError | null;
+	/** `true` while the camera is starting and not yet active (no error). */
+	isLoading: boolean;
+	/**
+	 * Clears the current error and restarts the camera. Wire this to a retry
+	 * control. Provided by `Scanner`; only meaningful while `error` is set.
+	 */
+	onRetry?: () => void;
+}

--- a/src/types/IStopTaskResult.ts
+++ b/src/types/IStopTaskResult.ts
@@ -1,4 +1,0 @@
-export interface IStopTaskResult {
-	type: 'stop';
-	data: {};
-}

--- a/src/types/IUseScannerState.ts
+++ b/src/types/IUseScannerState.ts
@@ -1,6 +1,0 @@
-export interface IUseScannerState {
-	lastScan: number;
-	lastOnScan: number;
-	contentBefore: Set<string>;
-	lastScanHadContent: boolean;
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,10 @@
 export type { IBoundingBox } from './IBoundingBox';
+export type {
+	ICameraCapabilities,
+	ICameraSettings,
+} from './ICameraCapabilities';
 export type { IDetectedBarcode } from './IDetectedBarcode';
+export type { IFinderConfig } from './IFinderConfig';
 export type { IPoint } from './IPoint';
 export type { IScannerClassNames } from './IScannerClassNames';
 export type { IScannerComponents } from './IScannerComponents';
@@ -10,7 +15,5 @@ export type {
 export type { IScannerHandle } from './IScannerHandle';
 export type { IScannerStyles } from './IScannerStyles';
 export type { IStartCamera } from './IStartCamera';
-export type { IStartTaskResult } from './IStartTaskResult';
-export type { IStopTaskResult } from './IStopTaskResult';
-export type { IUseScannerState } from './IUseScannerState';
+export type { IStatusOverlayState } from './IStatusOverlayState';
 export type { TrackFunction } from './TrackFunction';

--- a/src/types/internal.ts
+++ b/src/types/internal.ts
@@ -1,0 +1,24 @@
+// Internal implementation types — NOT part of the public API and intentionally
+// not re-exported from `./index`. They describe the camera task-queue results
+// (useCamera) and the per-frame scanner state machine (useScanner).
+
+export interface IStartTaskResult {
+	type: 'start';
+	data: {
+		videoEl: HTMLVideoElement;
+		stream: MediaStream;
+		constraints: MediaTrackConstraints;
+	};
+}
+
+export interface IStopTaskResult {
+	type: 'stop';
+	data: {};
+}
+
+export interface IUseScannerState {
+	lastScan: number;
+	lastOnScan: number;
+	contentBefore: Set<string>;
+	lastScanHadContent: boolean;
+}

--- a/src/utilities/coordinateTransform.ts
+++ b/src/utilities/coordinateTransform.ts
@@ -1,0 +1,112 @@
+import type { IDetectedBarcode, IPoint } from '../types';
+
+/** Display vs. intrinsic dimensions of the video element. */
+export interface IDisplayGeometry {
+	/** Rendered width of the video element (CSS pixels). */
+	displayWidth: number;
+	/** Rendered height of the video element (CSS pixels). */
+	displayHeight: number;
+	/** Intrinsic width of the video stream. */
+	resolutionWidth: number;
+	/** Intrinsic height of the video stream. */
+	resolutionHeight: number;
+}
+
+/** Scale + offset that maps resolution-space coordinates to display space. */
+export interface ICoordinateTransform {
+	xScalar: number;
+	yScalar: number;
+	xOffset: number;
+	yOffset: number;
+}
+
+/**
+ * Computes the scale and centering offset that maps a barcode coordinate from
+ * the video's intrinsic resolution space into the displayed element's space.
+ *
+ * The video is rendered with `object-fit: cover`, so the larger dimension ratio
+ * is used, and the overflow is centered (which yields a negative offset on the
+ * cropped axis). Returns zeroed scalars when the resolution is unknown, so the
+ * caller can skip drawing.
+ */
+export function computeTransform(
+	geometry: IDisplayGeometry,
+): ICoordinateTransform {
+	const { displayWidth, displayHeight, resolutionWidth, resolutionHeight } =
+		geometry;
+
+	if (resolutionWidth === 0 || resolutionHeight === 0) {
+		return { xScalar: 0, yScalar: 0, xOffset: 0, yOffset: 0 };
+	}
+
+	const largerRatio = Math.max(
+		displayWidth / resolutionWidth,
+		displayHeight / resolutionHeight,
+	);
+
+	const uncutWidth = resolutionWidth * largerRatio;
+	const uncutHeight = resolutionHeight * largerRatio;
+
+	return {
+		xScalar: uncutWidth / resolutionWidth,
+		yScalar: uncutHeight / resolutionHeight,
+		xOffset: (displayWidth - uncutWidth) / 2,
+		yOffset: (displayHeight - uncutHeight) / 2,
+	};
+}
+
+/** Scales a point from resolution space toward display space. */
+export function scalePoint(
+	point: IPoint,
+	transform: ICoordinateTransform,
+): IPoint {
+	return {
+		x: Math.floor(point.x * transform.xScalar),
+		y: Math.floor(point.y * transform.yScalar),
+	};
+}
+
+/** Translates a (scaled) point by the centering offset. */
+export function translatePoint(
+	point: IPoint,
+	transform: ICoordinateTransform,
+): IPoint {
+	return {
+		x: Math.floor(point.x + transform.xOffset),
+		y: Math.floor(point.y + transform.yOffset),
+	};
+}
+
+/**
+ * Maps a detected barcode's `boundingBox` and `cornerPoints` from resolution
+ * space into display space, so a tracker overlay drawn on the display-sized
+ * canvas lines up with what the user sees.
+ */
+export function adjustBarcodeCoordinates(
+	detectedCode: IDetectedBarcode,
+	transform: ICoordinateTransform,
+): IDetectedBarcode {
+	const { boundingBox, cornerPoints } = detectedCode;
+
+	const topLeft = translatePoint(
+		scalePoint({ x: boundingBox.x, y: boundingBox.y }, transform),
+		transform,
+	);
+	const size = scalePoint(
+		{ x: boundingBox.width, y: boundingBox.height },
+		transform,
+	);
+
+	return {
+		...detectedCode,
+		cornerPoints: cornerPoints.map((point) =>
+			translatePoint(scalePoint(point, transform), transform),
+		),
+		boundingBox: {
+			x: topLeft.x,
+			y: topLeft.y,
+			width: size.x,
+			height: size.y,
+		},
+	};
+}

--- a/stories/Customization.stories.tsx
+++ b/stories/Customization.stories.tsx
@@ -1,0 +1,85 @@
+import { type CSSProperties, useState } from 'react';
+
+import { Scanner as ScannerComp } from '../src';
+
+const containerStyle: CSSProperties = {
+	width: '80%',
+	maxWidth: 500,
+	margin: 'auto',
+};
+
+const infoStyle: CSSProperties = {
+	marginTop: 8,
+	padding: 8,
+	background: '#f3f4f6',
+	borderRadius: 4,
+	fontFamily: 'monospace',
+	fontSize: 12,
+};
+
+function ThemedFinderTemplate() {
+	return (
+		<div style={containerStyle}>
+			<ScannerComp
+				onScan={() => undefined}
+				components={{
+					finder: { color: '#22c55e', size: '60%', borderRadius: '1rem' },
+					onOff: true,
+					torch: true,
+					zoom: true,
+				}}
+			/>
+		</div>
+	);
+}
+
+function StatusOverlayTemplate() {
+	return (
+		<div style={containerStyle}>
+			{/* Pass a non-existent deviceId to force an error and show the overlay. */}
+			<ScannerComp
+				onScan={() => undefined}
+				constraints={{ deviceId: 'does-not-exist' }}
+				components={{ statusOverlay: true }}
+			/>
+		</div>
+	);
+}
+
+function ObservabilityTemplate() {
+	const [active, setActive] = useState(false);
+	const [lastDetected, setLastDetected] = useState('—');
+	const [torch, setTorch] = useState(false);
+	const [zoom, setZoom] = useState(false);
+
+	return (
+		<div style={containerStyle}>
+			<ScannerComp
+				onScan={() => undefined}
+				onCameraActive={setActive}
+				onDetected={(codes) =>
+					setLastDetected(codes.map((c) => c.rawValue).join(', '))
+				}
+				onCapabilitiesChange={(capabilities) => {
+					// `torch`/`zoom` are typed via ICameraCapabilities — no global
+					// augmentation needed in consumer code.
+					setTorch(Boolean(capabilities.torch));
+					setZoom(Boolean(capabilities.zoom));
+				}}
+			/>
+			<pre style={infoStyle}>
+				{`cameraActive=${active}\n` +
+					`torchSupported=${torch} zoomSupported=${zoom}\n` +
+					`lastDetected=${lastDetected}`}
+			</pre>
+		</div>
+	);
+}
+
+export const ThemedFinder = ThemedFinderTemplate.bind({});
+export const StatusOverlay = StatusOverlayTemplate.bind({});
+export const Observability = ObservabilityTemplate.bind({});
+
+export default {
+	title: 'Customization',
+};

--- a/stories/ImperativeRef.stories.tsx
+++ b/stories/ImperativeRef.stories.tsx
@@ -26,25 +26,56 @@ const infoStyle: CSSProperties = {
 function Template() {
 	const scannerRef = useRef<IScannerHandle>(null);
 	const [info, setInfo] = useState<string>('');
+	const [snapshotUrl, setSnapshotUrl] = useState<string | null>(null);
+
+	function inspectCameraState() {
+		const state = scannerRef.current?.getCameraState();
+
+		if (state === undefined) return;
+
+		setInfo(
+			`isActive=${state.isActive}\n` +
+				`capabilities=${JSON.stringify(state.capabilities)}\n` +
+				`settings=${JSON.stringify(state.settings)}`,
+		);
+	}
+
+	async function takeSnapshot() {
+		const blob = await scannerRef.current?.snapshot();
+
+		if (!blob) {
+			setInfo('No frame available to snapshot.');
+			return;
+		}
+
+		setSnapshotUrl(URL.createObjectURL(blob));
+	}
 
 	function inspectStream() {
 		const stream = scannerRef.current?.getStream();
+
 		if (stream === null || stream === undefined) {
 			setInfo('No active stream.');
+
 			return;
 		}
+
 		const tracks = stream
 			.getTracks()
 			.map((t) => `${t.kind}: ${t.label || t.id}`);
+
 		setInfo(`Stream id ${stream.id}\nTracks:\n  ${tracks.join('\n  ')}`);
 	}
 
 	function inspectVideo() {
 		const video = scannerRef.current?.getVideoElement();
+
 		if (video === null || video === undefined) {
 			setInfo('No video element.');
+
 			return;
 		}
+
 		setInfo(
 			`videoWidth=${video.videoWidth} videoHeight=${video.videoHeight} ` +
 				`readyState=${video.readyState} paused=${video.paused}`,
@@ -60,9 +91,33 @@ function Template() {
 				<button type="button" onClick={inspectVideo}>
 					Inspect video element
 				</button>
+				<button type="button" onClick={inspectCameraState}>
+					Camera state
+				</button>
+			</div>
+			<div style={buttonRowStyle}>
+				<button type="button" onClick={takeSnapshot}>
+					Snapshot
+				</button>
+				<button type="button" onClick={() => scannerRef.current?.toggleTorch()}>
+					Toggle torch
+				</button>
+				<button type="button" onClick={() => scannerRef.current?.setZoom(2)}>
+					Zoom 2x
+				</button>
+				<button type="button" onClick={() => scannerRef.current?.restart()}>
+					Restart
+				</button>
 			</div>
 			<ScannerComp ref={scannerRef} onScan={() => undefined} />
 			{info.length > 0 && <pre style={infoStyle}>{info}</pre>}
+			{snapshotUrl !== null && (
+				<img
+					src={snapshotUrl}
+					alt="Captured frame"
+					style={{ marginTop: 8, maxWidth: '100%', borderRadius: 4 }}
+				/>
+			)}
 		</div>
 	);
 }

--- a/test/components/ControlFocusStyle.test.tsx
+++ b/test/components/ControlFocusStyle.test.tsx
@@ -1,0 +1,15 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ControlFocusStyle, {
+	CONTROL_FOCUS_CSS,
+} from '../../src/components/ControlFocusStyle';
+
+describe('ControlFocusStyle', () => {
+	it('renders the shared focus-visible rule as a stylesheet', () => {
+		const { container } = render(<ControlFocusStyle />);
+		const style = container.querySelector('style');
+
+		expect(style?.textContent).toBe(CONTROL_FOCUS_CSS);
+		expect(CONTROL_FOCUS_CSS).toContain('.rqs-control:focus-visible');
+	});
+});

--- a/test/components/Finder.test.tsx
+++ b/test/components/Finder.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Finder from '../../src/components/Finder';
+
+const baseProps = {
+	scanning: true,
+	startScanning: vi.fn(),
+	stopScanning: vi.fn(),
+};
+
+describe('Finder', () => {
+	it('renders the overlay without controls by default', () => {
+		render(<Finder {...baseProps} capabilities={{}} />);
+
+		expect(screen.queryByRole('button')).toBeNull();
+	});
+
+	it('renders the on/off control when enabled', () => {
+		render(<Finder {...baseProps} capabilities={{}} onOff />);
+
+		expect(screen.getByRole('button', { name: /camera/i })).toBeTruthy();
+	});
+
+	it('only renders the torch control when the device supports it', () => {
+		const torch = { status: false, toggle: vi.fn() };
+
+		const { rerender } = render(
+			<Finder {...baseProps} capabilities={{}} torch={torch} />,
+		);
+		expect(screen.queryByRole('button', { name: /flashlight/i })).toBeNull();
+
+		rerender(
+			<Finder {...baseProps} capabilities={{ torch: true }} torch={torch} />,
+		);
+		expect(screen.getByRole('button', { name: /flashlight/i })).toBeTruthy();
+	});
+
+	it('only renders the zoom control when the device supports it', () => {
+		const zoom = { value: 2, onChange: vi.fn() };
+
+		render(
+			<Finder
+				{...baseProps}
+				capabilities={{ zoom: { min: 1, max: 5, step: 1 } }}
+				zoom={zoom}
+			/>,
+		);
+
+		expect(screen.getByRole('button', { name: 'Zoom in' })).toBeTruthy();
+		expect(screen.getByRole('button', { name: 'Zoom out' })).toBeTruthy();
+	});
+
+	it('applies a custom finder color', () => {
+		const { container } = render(
+			<Finder {...baseProps} capabilities={{}} color="#00ff00" />,
+		);
+
+		expect(container.innerHTML).toContain('#00ff00');
+	});
+});

--- a/test/components/OnOff.test.tsx
+++ b/test/components/OnOff.test.tsx
@@ -1,0 +1,78 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import OnOff from '../../src/components/OnOff';
+
+describe('OnOff', () => {
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('shows the "on" affordance when stopped and starts on click', () => {
+		const startScanning = vi.fn();
+		const stopScanning = vi.fn();
+
+		render(
+			<OnOff
+				scanning={false}
+				startScanning={startScanning}
+				stopScanning={stopScanning}
+			/>,
+		);
+
+		const button = screen.getByRole('button', { name: 'Turn camera on' });
+		expect(button.getAttribute('aria-pressed')).toBe('false');
+
+		fireEvent.click(button);
+
+		expect(startScanning).toHaveBeenCalledTimes(1);
+		expect(stopScanning).not.toHaveBeenCalled();
+	});
+
+	it('shows the "off" affordance when scanning and stops on click', () => {
+		const startScanning = vi.fn();
+		const stopScanning = vi.fn();
+
+		render(
+			<OnOff
+				scanning
+				startScanning={startScanning}
+				stopScanning={stopScanning}
+			/>,
+		);
+
+		const button = screen.getByRole('button', { name: 'Turn camera off' });
+		expect(button.getAttribute('aria-pressed')).toBe('true');
+
+		fireEvent.click(button);
+
+		expect(stopScanning).toHaveBeenCalledTimes(1);
+	});
+
+	it('debounces rapid toggles by disabling the button for ~1s', () => {
+		vi.useFakeTimers();
+
+		const startScanning = vi.fn();
+
+		render(
+			<OnOff
+				scanning={false}
+				startScanning={startScanning}
+				stopScanning={vi.fn()}
+			/>,
+		);
+
+		const button = screen.getByRole<HTMLButtonElement>('button');
+
+		fireEvent.click(button);
+		expect(button.disabled).toBe(true);
+
+		// A second click while disabled is ignored.
+		fireEvent.click(button);
+		expect(startScanning).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			vi.advanceTimersByTime(1000);
+		});
+		expect(button.disabled).toBe(false);
+	});
+});

--- a/test/components/Scanner.overlay.test.tsx
+++ b/test/components/Scanner.overlay.test.tsx
@@ -1,0 +1,78 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { startCamera, stopCamera } = vi.hoisted(() => ({
+	startCamera: vi.fn(async () => undefined),
+	stopCamera: vi.fn(async () => undefined),
+}));
+
+vi.mock('../../src/hooks/useCamera', () => ({
+	default: () => ({
+		capabilities: {},
+		settings: {},
+		startCamera,
+		stopCamera,
+		updateConstraints: vi.fn(async () => undefined),
+		flush: vi.fn(async () => undefined),
+		getStream: () => null,
+	}),
+}));
+
+vi.mock('../../src/hooks/useScanner', () => ({
+	default: () => ({ startScanning: vi.fn(), stopScanning: vi.fn() }),
+}));
+
+import { Scanner } from '../../src';
+
+describe('Scanner status overlay recovery', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'error').mockImplementation(() => undefined);
+		// happy-dom has no 2D canvas; Scanner only needs a context handle to
+		// snapshot frames, so a stub with the methods it calls is enough.
+		vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+			drawImage: vi.fn(),
+		} as unknown as CanvasRenderingContext2D);
+		startCamera.mockReset();
+		stopCamera.mockReset().mockResolvedValue(undefined);
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	async function flushAsyncWork() {
+		for (let i = 0; i < 10; i++) {
+			await new Promise((r) => setTimeout(r, 0));
+		}
+	}
+
+	it('shows a non-blocking error overlay with a working retry after a start failure', async () => {
+		startCamera.mockRejectedValue(new Error('boom'));
+
+		render(
+			<Scanner
+				onScan={() => undefined}
+				components={{ statusOverlay: true, onOff: true }}
+			/>,
+		);
+
+		await flushAsyncWork();
+
+		const alert = await screen.findByRole('alert');
+		// The backdrop must not intercept clicks meant for the controls beneath.
+		expect(alert.style.pointerEvents).toBe('none');
+		// The built-in on/off control still exists underneath the overlay.
+		expect(
+			screen.getByRole('button', { name: /turn camera on/i }),
+		).toBeTruthy();
+
+		const callsBeforeRetry = startCamera.mock.calls.length;
+		startCamera.mockResolvedValue(undefined);
+
+		fireEvent.click(screen.getByRole('button', { name: /retry/i }));
+		await flushAsyncWork();
+
+		// Retry routes back through the camera-start path.
+		expect(startCamera.mock.calls.length).toBeGreaterThan(callsBeforeRetry);
+	});
+});

--- a/test/components/Scanner.ref.test.tsx
+++ b/test/components/Scanner.ref.test.tsx
@@ -1,0 +1,71 @@
+import { render } from '@testing-library/react';
+import { createRef } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { IScannerHandle } from '../../src/types';
+
+const updateConstraints = vi.fn(async () => undefined);
+
+vi.mock('../../src/hooks/useCamera', () => ({
+	default: () => ({
+		capabilities: { torch: true, zoom: { min: 1, max: 5, step: 1 } },
+		settings: { torch: false, zoom: 2 },
+		startCamera: vi.fn(async () => undefined),
+		stopCamera: vi.fn(async () => undefined),
+		updateConstraints,
+		flush: vi.fn(async () => undefined),
+		getStream: () => null,
+	}),
+}));
+
+vi.mock('../../src/hooks/useScanner', () => ({
+	default: () => ({ startScanning: vi.fn(), stopScanning: vi.fn() }),
+}));
+
+import { Scanner } from '../../src/components/Scanner';
+
+describe('Scanner imperative handle', () => {
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('exposes camera state from the active track', () => {
+		const ref = createRef<IScannerHandle>();
+		render(<Scanner ref={ref} onScan={() => undefined} />);
+
+		const handle = ref.current;
+		if (handle === null) throw new Error('ref was not attached');
+
+		const state = handle.getCameraState();
+		expect(state.capabilities.torch).toBe(true);
+		expect(state.settings.zoom).toBe(2);
+	});
+
+	it('resolves snapshot() to null when no frame is available', async () => {
+		const ref = createRef<IScannerHandle>();
+		render(<Scanner ref={ref} onScan={() => undefined} />);
+
+		const handle = ref.current;
+		if (handle === null) throw new Error('ref was not attached');
+
+		// happy-dom video has no intrinsic dimensions.
+		await expect(handle.snapshot()).resolves.toBeNull();
+	});
+
+	it('proxies torch and zoom through updateConstraints', async () => {
+		const ref = createRef<IScannerHandle>();
+		render(<Scanner ref={ref} onScan={() => undefined} />);
+
+		const handle = ref.current;
+		if (handle === null) throw new Error('ref was not attached');
+
+		await handle.toggleTorch(true);
+		expect(updateConstraints).toHaveBeenCalledWith(
+			expect.objectContaining({ advanced: [{ torch: true }] }),
+		);
+
+		await handle.setZoom(3);
+		expect(updateConstraints).toHaveBeenCalledWith(
+			expect.objectContaining({ advanced: [{ zoom: 3 }] }),
+		);
+	});
+});

--- a/test/components/Scanner.test.tsx
+++ b/test/components/Scanner.test.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('../hooks/useCamera', () => ({
+vi.mock('../../src/hooks/useCamera', () => ({
 	default: () => ({
 		capabilities: {},
 		settings: {},
@@ -13,14 +13,14 @@ vi.mock('../hooks/useCamera', () => ({
 	}),
 }));
 
-vi.mock('../hooks/useScanner', () => ({
+vi.mock('../../src/hooks/useScanner', () => ({
 	default: () => ({
 		startScanning: vi.fn(),
 		stopScanning: vi.fn(),
 	}),
 }));
 
-import { Scanner } from './Scanner';
+import { Scanner } from '../../src/components/Scanner';
 
 describe('Scanner', () => {
 	let errorSpy: ReturnType<typeof vi.spyOn>;

--- a/test/components/StatusOverlay.test.tsx
+++ b/test/components/StatusOverlay.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import StatusOverlay from '../../src/components/StatusOverlay';
+import type { IScannerError } from '../../src/types';
+
+function error(kind: IScannerError['kind']): IScannerError {
+	return { kind, message: `raw ${kind}`, cause: null };
+}
+
+describe('StatusOverlay', () => {
+	it('renders nothing when idle (no error, not loading)', () => {
+		const { container } = render(
+			<StatusOverlay error={null} isLoading={false} />,
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('shows a loading status while starting', () => {
+		render(<StatusOverlay error={null} isLoading />);
+
+		const status = screen.getByRole('status');
+		expect(status.textContent).toContain('Starting camera');
+	});
+
+	it('maps known error kinds to friendly alert messages', () => {
+		render(
+			<StatusOverlay error={error('permission-denied')} isLoading={false} />,
+		);
+
+		const alert = screen.getByRole('alert');
+		expect(alert.textContent).toMatch(/denied/i);
+		// The raw technical message is not surfaced for known kinds.
+		expect(alert.textContent).not.toContain('raw permission-denied');
+	});
+
+	it('prioritizes the error over the loading state', () => {
+		render(<StatusOverlay error={error('no-camera')} isLoading />);
+
+		expect(screen.queryByRole('status')).toBeNull();
+		expect(screen.getByRole('alert').textContent).toMatch(/no camera/i);
+	});
+
+	it('keeps the backdrop non-blocking so controls beneath stay clickable', () => {
+		const { rerender } = render(<StatusOverlay error={null} isLoading />);
+		expect(screen.getByRole('status').style.pointerEvents).toBe('none');
+
+		rerender(<StatusOverlay error={error('in-use')} isLoading={false} />);
+		expect(screen.getByRole('alert').style.pointerEvents).toBe('none');
+	});
+
+	it('renders a clickable retry control for recoverable errors', () => {
+		const onRetry = vi.fn();
+		render(
+			<StatusOverlay
+				error={error('in-use')}
+				isLoading={false}
+				onRetry={onRetry}
+			/>,
+		);
+
+		const button = screen.getByRole('button', { name: /retry/i });
+		// The button opts back into pointer events even though the backdrop is inert.
+		expect(button.style.pointerEvents).toBe('auto');
+
+		fireEvent.click(button);
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it('omits the retry control for errors a retry cannot resolve', () => {
+		const onRetry = vi.fn();
+
+		for (const kind of ['unsupported', 'insecure-context'] as const) {
+			const { unmount } = render(
+				<StatusOverlay
+					error={error(kind)}
+					isLoading={false}
+					onRetry={onRetry}
+				/>,
+			);
+
+			expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+			unmount();
+		}
+	});
+
+	it('omits the retry control when no handler is provided', () => {
+		render(<StatusOverlay error={error('in-use')} isLoading={false} />);
+
+		expect(screen.queryByRole('button', { name: /retry/i })).toBeNull();
+	});
+});

--- a/test/components/StatusOverlay.test.tsx
+++ b/test/components/StatusOverlay.test.tsx
@@ -67,6 +67,22 @@ describe('StatusOverlay', () => {
 		expect(onRetry).toHaveBeenCalledTimes(1);
 	});
 
+	it('injects the .rqs-control focus-ring stylesheet alongside the retry button', () => {
+		const { container } = render(
+			<StatusOverlay
+				error={error('in-use')}
+				isLoading={false}
+				onRetry={vi.fn()}
+			/>,
+		);
+
+		expect(screen.getByRole('button', { name: /retry/i })).toBeTruthy();
+
+		const style = container.querySelector('style');
+		expect(style).not.toBeNull();
+		expect(style?.textContent).toContain('.rqs-control:focus-visible');
+	});
+
 	it('omits the retry control for errors a retry cannot resolve', () => {
 		const onRetry = vi.fn();
 

--- a/test/components/Torch.test.tsx
+++ b/test/components/Torch.test.tsx
@@ -1,0 +1,39 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Torch from '../../src/components/Torch';
+
+describe('Torch', () => {
+	it('renders nothing while not scanning', () => {
+		const { container } = render(
+			<Torch scanning={false} status={false} torchToggle={vi.fn()} />,
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('turns the torch on when currently off', () => {
+		const torchToggle = vi.fn();
+
+		render(<Torch scanning status={false} torchToggle={torchToggle} />);
+
+		const button = screen.getByRole('button', { name: 'Turn flashlight on' });
+		expect(button.getAttribute('aria-pressed')).toBe('false');
+
+		fireEvent.click(button);
+
+		expect(torchToggle).toHaveBeenCalledWith(true);
+	});
+
+	it('turns the torch off when currently on', () => {
+		const torchToggle = vi.fn();
+
+		render(<Torch scanning status torchToggle={torchToggle} />);
+
+		const button = screen.getByRole('button', { name: 'Turn flashlight off' });
+		expect(button.getAttribute('aria-pressed')).toBe('true');
+
+		fireEvent.click(button);
+
+		expect(torchToggle).toHaveBeenCalledWith(false);
+	});
+});

--- a/test/components/Zoom.test.tsx
+++ b/test/components/Zoom.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import Zoom from '../../src/components/Zoom';
+
+const capabilities = { min: 1, max: 5, step: 1 };
+
+describe('Zoom', () => {
+	it('renders nothing while not scanning', () => {
+		const { container } = render(
+			<Zoom
+				scanning={false}
+				capabilities={capabilities}
+				value={3}
+				onZoom={vi.fn()}
+			/>,
+		);
+
+		expect(container.firstChild).toBeNull();
+	});
+
+	it('zooms in and out by one step, clamped to capabilities', () => {
+		const onZoom = vi.fn();
+
+		render(
+			<Zoom scanning capabilities={capabilities} value={3} onZoom={onZoom} />,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Zoom in' }));
+		expect(onZoom).toHaveBeenLastCalledWith(4);
+
+		fireEvent.click(screen.getByRole('button', { name: 'Zoom out' }));
+		expect(onZoom).toHaveBeenLastCalledWith(2);
+	});
+
+	it('disables zoom out at the minimum', () => {
+		render(
+			<Zoom scanning capabilities={capabilities} value={1} onZoom={vi.fn()} />,
+		);
+
+		expect(
+			screen.getByRole<HTMLButtonElement>('button', { name: 'Zoom out' })
+				.disabled,
+		).toBe(true);
+		expect(
+			screen.getByRole<HTMLButtonElement>('button', { name: 'Zoom in' })
+				.disabled,
+		).toBe(false);
+	});
+
+	it('disables zoom in at the maximum', () => {
+		render(
+			<Zoom scanning capabilities={capabilities} value={5} onZoom={vi.fn()} />,
+		);
+
+		expect(
+			screen.getByRole<HTMLButtonElement>('button', { name: 'Zoom in' })
+				.disabled,
+		).toBe(true);
+	});
+});

--- a/test/hooks/useCamera.test.tsx
+++ b/test/hooks/useCamera.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import useCamera from './useCamera';
+import useCamera from '../../src/hooks/useCamera';
 
 interface IMockTrack {
 	getSettings: ReturnType<typeof vi.fn>;

--- a/test/hooks/useDevices.test.tsx
+++ b/test/hooks/useDevices.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { useDevices } from './useDevices';
+import { useDevices } from '../../src/hooks/useDevices';
 
 type DeviceListener = (event: Event) => void;
 

--- a/test/hooks/useScanner.test.tsx
+++ b/test/hooks/useScanner.test.tsx
@@ -10,7 +10,7 @@ vi.mock('barcode-detector/ponyfill', () => ({
 	},
 }));
 
-import useScanner from './useScanner';
+import useScanner from '../../src/hooks/useScanner';
 
 function setReadyState(el: HTMLVideoElement, value: number) {
 	Object.defineProperty(el, 'readyState', {

--- a/test/utilities/coordinateTransform.test.ts
+++ b/test/utilities/coordinateTransform.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { IDetectedBarcode } from '../../src/types';
+import {
+	adjustBarcodeCoordinates,
+	computeTransform,
+	scalePoint,
+	translatePoint,
+} from '../../src/utilities/coordinateTransform';
+
+describe('computeTransform', () => {
+	it('returns a uniform 1:1 transform when display matches resolution', () => {
+		const t = computeTransform({
+			displayWidth: 100,
+			displayHeight: 100,
+			resolutionWidth: 100,
+			resolutionHeight: 100,
+		});
+
+		expect(t).toEqual({ xScalar: 1, yScalar: 1, xOffset: 0, yOffset: 0 });
+	});
+
+	it('scales uniformly and keeps zero offset when aspect ratios match', () => {
+		const t = computeTransform({
+			displayWidth: 200,
+			displayHeight: 200,
+			resolutionWidth: 100,
+			resolutionHeight: 100,
+		});
+
+		expect(t).toEqual({ xScalar: 2, yScalar: 2, xOffset: 0, yOffset: 0 });
+	});
+
+	it('uses the larger ratio and centers the cropped axis (object-fit: cover)', () => {
+		// Wider display than the source: width drives the scale (×2), and the
+		// vertical overflow is centered with a negative offset (top/bottom crop).
+		const t = computeTransform({
+			displayWidth: 200,
+			displayHeight: 100,
+			resolutionWidth: 100,
+			resolutionHeight: 100,
+		});
+
+		expect(t.xScalar).toBe(2);
+		expect(t.yScalar).toBe(2);
+		expect(t.xOffset).toBe(0);
+		expect(t.yOffset).toBe(-50);
+	});
+
+	it('returns a zeroed transform when the resolution is unknown', () => {
+		expect(
+			computeTransform({
+				displayWidth: 200,
+				displayHeight: 200,
+				resolutionWidth: 0,
+				resolutionHeight: 0,
+			}),
+		).toEqual({ xScalar: 0, yScalar: 0, xOffset: 0, yOffset: 0 });
+	});
+});
+
+describe('scalePoint / translatePoint', () => {
+	const transform = { xScalar: 2, yScalar: 2, xOffset: 0, yOffset: -50 };
+
+	it('scales and floors', () => {
+		expect(scalePoint({ x: 10, y: 21 }, transform)).toEqual({ x: 20, y: 42 });
+	});
+
+	it('translates by the offset and floors', () => {
+		expect(translatePoint({ x: 20, y: 42 }, transform)).toEqual({
+			x: 20,
+			y: -8,
+		});
+	});
+});
+
+describe('adjustBarcodeCoordinates', () => {
+	it('maps boundingBox and cornerPoints into display space', () => {
+		const code: IDetectedBarcode = {
+			boundingBox: { x: 10, y: 20, width: 30, height: 40 },
+			cornerPoints: [
+				{ x: 10, y: 20 },
+				{ x: 40, y: 20 },
+				{ x: 40, y: 60 },
+				{ x: 10, y: 60 },
+			],
+			format: 'qr_code',
+			rawValue: 'hello',
+		};
+
+		const transform = computeTransform({
+			displayWidth: 200,
+			displayHeight: 200,
+			resolutionWidth: 100,
+			resolutionHeight: 100,
+		});
+
+		const adjusted = adjustBarcodeCoordinates(code, transform);
+
+		// ×2 uniform scale, no offset.
+		expect(adjusted.boundingBox).toEqual({
+			x: 20,
+			y: 40,
+			width: 60,
+			height: 80,
+		});
+		expect(adjusted.cornerPoints).toEqual([
+			{ x: 20, y: 40 },
+			{ x: 80, y: 40 },
+			{ x: 80, y: 120 },
+			{ x: 20, y: 120 },
+		]);
+		// Non-coordinate fields are preserved.
+		expect(adjusted.format).toBe('qr_code');
+		expect(adjusted.rawValue).toBe('hello');
+	});
+});

--- a/test/utilities/createScannerError.test.ts
+++ b/test/utilities/createScannerError.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { createScannerError } from './createScannerError';
+import { createScannerError } from '../../src/utilities/createScannerError';
 
 function makeDomException(name: string, message = ''): DOMException {
 	const err = new Error(message) as Error & { name: string };

--- a/test/utilities/deepEqual.test.ts
+++ b/test/utilities/deepEqual.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import deepEqual from './deepEqual';
+import deepEqual from '../../src/utilities/deepEqual';
 
 describe('deepEqual', () => {
 	it('compares primitives by identity', () => {

--- a/test/utilities/isBarcodeDetectorSupported.test.ts
+++ b/test/utilities/isBarcodeDetectorSupported.test.ts
@@ -6,7 +6,7 @@ describe('isBarcodeDetectorSupported', () => {
 		(globalThis as { BarcodeDetector?: unknown }).BarcodeDetector = class {};
 
 		const { isBarcodeDetectorSupported } = await import(
-			'./isBarcodeDetectorSupported'
+			'../../src/utilities/isBarcodeDetectorSupported'
 		);
 
 		expect(isBarcodeDetectorSupported()).toBe(true);
@@ -19,7 +19,7 @@ describe('isBarcodeDetectorSupported', () => {
 		delete (globalThis as { BarcodeDetector?: unknown }).BarcodeDetector;
 
 		const { isBarcodeDetectorSupported } = await import(
-			'./isBarcodeDetectorSupported'
+			'../../src/utilities/isBarcodeDetectorSupported'
 		);
 
 		expect(isBarcodeDetectorSupported()).toBe(false);
@@ -30,7 +30,7 @@ describe('isBarcodeDetectorSupported', () => {
 		delete (globalThis as { BarcodeDetector?: unknown }).BarcodeDetector;
 
 		const { isBarcodeDetectorSupported } = await import(
-			'./isBarcodeDetectorSupported'
+			'../../src/utilities/isBarcodeDetectorSupported'
 		);
 
 		// Simulate a consumer (or a side-effect import) installing the polyfill

--- a/test/utilities/isObject.test.ts
+++ b/test/utilities/isObject.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import isObject from './isObject';
+import isObject from '../../src/utilities/isObject';
 
 describe('isObject', () => {
 	it('returns true for plain objects', () => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": ".",
+		"noEmit": true
+	},
+	"include": ["src", "test"]
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,17 +4,19 @@ export default defineConfig({
 	test: {
 		environment: 'happy-dom',
 		globals: true,
-		include: ['src/**/*.test.{ts,tsx}', 'tests/**/*.test.{ts,tsx}'],
+		include: ['test/**/*.test.{ts,tsx}'],
 		coverage: {
 			provider: 'v8',
 			reporter: ['text', 'lcov', 'html'],
 			include: ['src/**/*.{ts,tsx}'],
-			exclude: [
-				'src/**/*.test.{ts,tsx}',
-				'src/**/index.ts',
-				'src/types/**',
-				'src/assets/**',
-			],
+			exclude: ['src/**/index.ts', 'src/types/**', 'src/assets/**'],
+			// Gate against regressions. Raise these as coverage improves.
+			thresholds: {
+				statements: 58,
+				branches: 58,
+				functions: 58,
+				lines: 58,
+			},
 		},
 	},
 });


### PR DESCRIPTION
## Summary

Expands the `Scanner` surface with new observability callbacks, an imperative control API, an opt-in status overlay, finder theming, and accessibility improvements — plus a more efficient detection loop. Tests are relocated to a dedicated `test/` tree with a coverage gate, and the README/stories are updated.

## What's new

**Scanner API**
- New callbacks: `onDetected` (raw per-frame stream, ahead of the `scanDelay`/duplicate gating), `onCameraActive`, and `onCapabilitiesChange`.
- Imperative ref (`IScannerHandle`) gains `getCameraState`, `snapshot`, `toggleTorch`, `setZoom`, and `restart`.
- `components.statusOverlay` — built-in loading/error UI with retry, or a custom render function.
- `components.finder` accepts an `IFinderConfig` (`color` / `size` / `borderRadius`) for theming.
- `useCamera` and `useScanner` are now exported as headless hooks for fully custom UIs.

**Accessibility**
- Screen-reader live region announcing decoded values, `aria-label` on the video feed, and `:focus-visible` rings on controls.
- RTL-friendly control positioning (`insetInlineEnd`) and disabled-state opacity.

**Detection loop & robustness**
- Uses `requestVideoFrameCallback` when available (fewer WASM calls on duplicate frames), falling back to `requestAnimationFrame`.
- Pauses detection on hidden tabs; primes audio on first user gesture so the first iOS/Safari scan isn't muted.
- Coordinate scaling extracted into a reusable, unit-tested `coordinateTransform` utility.

## Tests & tooling
- All unit tests moved from `src/**` into a dedicated `test/**` tree.
- vitest points at `test/**` with v8 coverage thresholds; the PR workflow runs `test:coverage`.
- Added `tsconfig.test.json` (typecheck now covers tests) and included `test/**` in Biome.

## Verification
- `npm run typecheck` — passes
- `npm test` — 70 tests across 16 files pass

## Commits
1. `feat: expand scanner API, controls, and a11y`
2. `test: relocate suite to test/ and add coverage gate`
3. `docs: document v3 APIs and refresh stories`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR significantly expands the `Scanner` surface area for v3: new observability callbacks (`onDetected`, `onCameraActive`, `onCapabilitiesChange`), an imperative `IScannerHandle` with snapshot/torch/zoom/restart, an opt-in status overlay with retry, finder theming via `IFinderConfig`, and a set of accessibility improvements (ARIA live region, `aria-label`, `:focus-visible` focus rings, RTL-safe positioning). The detection loop is also modernised with `requestVideoFrameCallback`.

- **Detection loop & robustness**: `useScanner` now uses `requestVideoFrameCallback` (falling back to `rAF`), correctly reschedules instead of returning early when `readyState ≤ 1`, and pauses on hidden tabs. Previously flagged issues (scan-loop freeze, spurious `onCameraActive`/`onCapabilitiesChange` on mount, and the `prefers-reduced-motion` specificity problem in `StatusOverlay`) are all correctly addressed.
- **Coordinate transform**: The inline scale/translate math in `drawTracking` is extracted into a dedicated, unit-tested `coordinateTransform` utility, and `boundingBox` now returns a plain `IBoundingBox` matching the typed interface rather than a `DOMRectReadOnly`.
- **Tests & tooling**: Test files moved to a dedicated `test/` tree; 70 tests across 16 files cover the new components, hooks, and utilities, with v8 coverage thresholds added to the CI workflow.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the two comments are minor style/documentation suggestions with no impact on correctness or runtime behavior.

The core logic changes are sound: the detection loop correctly reschedules on transient readyState drops, the sentinel-ref pattern prevents spurious callbacks under StrictMode, the animation is properly moved out of inline styles so the reduced-motion media query can override it, and the camera task queue serializes start/stop/updateConstraints safely. The only findings are a missing doc note about the torch side-effect of setZoom, and hardcoded English strings in accessibility attributes and overlay copy.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/components/Scanner.tsx | Major expansion: new callbacks (onDetected, onCameraActive, onCapabilitiesChange), imperative handle methods, status overlay, accessibility live region, and finder theming. Previously flagged Strict-Mode and spurious-callback issues are correctly addressed via sentinel refs. |
| src/hooks/useScanner.ts | Replaces rAF with rVFC (with rAF fallback), fixes the readyState<=1 freeze by rescheduling instead of returning early, adds iOS audio priming, and adds the pre-gate onDetected callback. Previously flagged scan-loop-dies issue is correctly resolved. |
| src/hooks/useCamera.ts | Minor: adds setCapabilities({}) in stopCamera to clear stale capabilities state on stop; internal types moved to types/internal. |
| src/components/StatusOverlay.tsx | New component; previously flagged prefers-reduced-motion/inline-style specificity issue is correctly resolved — animation is now assigned in the CSS class, not inline. |
| src/utilities/coordinateTransform.ts | New utility; extracts scale/translate/adjust logic from Scanner.tsx into tested, composable helpers. Returns plain IBoundingBox (matching the typed interface) instead of DOMRectReadOnly. |
| src/types/IScannerHandle.ts | Extended with getCameraState, snapshot, toggleTorch, setZoom, restart; setZoom doc comment does not mention that it silently disables the torch on certain devices. |
| src/components/Finder.tsx | Refactored to accept IFinderConfig (color/size/borderRadius); corner styles now computed inline per-render. RTL-friendly insetInlineEnd positioning added. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Ftypes%2FIScannerHandle.ts%3A35-36%0A**%60setZoom%60%20silently%20disables%20the%20torch%20%E2%80%94%20doc%20comment%20should%20note%20the%20side%20effect**%0A%0AIn%20%60useCamera.ts%60%2C%20%60updateConstraints%60%20automatically%20turns%20off%20the%20torch%20before%20applying%20a%20zoom%20constraint%2C%20because%20mobile%20browsers%20can't%20mix%20%60ImageCapture%60%20%28torch%29%20and%20non-%60ImageCapture%60%20%28zoom%29%20constraints.%20The%20current%20doc%20comment%20for%20%60setZoom%60%20only%20says%20%22the%20device%20clamps%20it%20to%20its%20supported%20range%22%20%E2%80%94%20it%20doesn't%20mention%20that%20calling%20%60setZoom%60%20while%20the%20torch%20is%20on%20will%20turn%20the%20torch%20off.%20Callers%20using%20%60toggleTorch%60%20and%20%60setZoom%60%20together%20will%20observe%20the%20torch%20being%20silently%20disabled%20on%20affected%20devices.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcomponents%2FScanner.tsx%3A551-553%0A**Hardcoded%20English%20strings%20are%20not%20localization-friendly**%0A%0AThe%20%60aria-label%60%20on%20the%20video%20element%20%28%60%22Barcode%20scanner%20camera%20feed%22%60%29%2C%20the%20screen-reader%20announcement%20%28%60%22Detected%3A%20%E2%80%A6%22%60%29%2C%20and%20the%20built-in%20overlay%20copy%20in%20%60StatusOverlay%60%20%28%22Starting%20camera%E2%80%A6%22%2C%20all%20error%20messages%2C%20%22Retry%22%29%20are%20all%20hard-coded%20English.%20Exposing%20a%20%60labels%60%20or%20%60i18n%60%20prop%20on%20%60Scanner%60%20%28or%20at%20minimum%20%60aria-label%60%20directly%29%20would%20allow%20non-English%20consumers%20to%20supply%20the%20correct%20translated%20text%20without%20forking%20the%20component.%0A%0A&repo=yudielcurbelo%2Freact-qr-scanner&pr=157&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22yudielcurbelo%2Freact-qr-scanner%22%20on%20the%20existing%20branch%20%22feat%2Fv3-improvements%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fv3-improvements%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Asrc%2Ftypes%2FIScannerHandle.ts%3A35-36%0A**%60setZoom%60%20silently%20disables%20the%20torch%20%E2%80%94%20doc%20comment%20should%20note%20the%20side%20effect**%0A%0AIn%20%60useCamera.ts%60%2C%20%60updateConstraints%60%20automatically%20turns%20off%20the%20torch%20before%20applying%20a%20zoom%20constraint%2C%20because%20mobile%20browsers%20can't%20mix%20%60ImageCapture%60%20%28torch%29%20and%20non-%60ImageCapture%60%20%28zoom%29%20constraints.%20The%20current%20doc%20comment%20for%20%60setZoom%60%20only%20says%20%22the%20device%20clamps%20it%20to%20its%20supported%20range%22%20%E2%80%94%20it%20doesn't%20mention%20that%20calling%20%60setZoom%60%20while%20the%20torch%20is%20on%20will%20turn%20the%20torch%20off.%20Callers%20using%20%60toggleTorch%60%20and%20%60setZoom%60%20together%20will%20observe%20the%20torch%20being%20silently%20disabled%20on%20affected%20devices.%0A%0A%23%23%23%20Issue%202%20of%202%0Asrc%2Fcomponents%2FScanner.tsx%3A551-553%0A**Hardcoded%20English%20strings%20are%20not%20localization-friendly**%0A%0AThe%20%60aria-label%60%20on%20the%20video%20element%20%28%60%22Barcode%20scanner%20camera%20feed%22%60%29%2C%20the%20screen-reader%20announcement%20%28%60%22Detected%3A%20%E2%80%A6%22%60%29%2C%20and%20the%20built-in%20overlay%20copy%20in%20%60StatusOverlay%60%20%28%22Starting%20camera%E2%80%A6%22%2C%20all%20error%20messages%2C%20%22Retry%22%29%20are%20all%20hard-coded%20English.%20Exposing%20a%20%60labels%60%20or%20%60i18n%60%20prop%20on%20%60Scanner%60%20%28or%20at%20minimum%20%60aria-label%60%20directly%29%20would%20allow%20non-English%20consumers%20to%20supply%20the%20correct%20translated%20text%20without%20forking%20the%20component.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (5): Last reviewed commit: ["fix: inject control focus ring in status..."](https://github.com/yudielcurbelo/react-qr-scanner/commit/8fe935115e439ed1ec973c0cdfeb1e6661734a22) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35418331)</sub>

<!-- /greptile_comment -->